### PR TITLE
feat: Add interactive buttons to auth error notification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ add_executable(Kgithub-notify
     src/SettingsDialog.h
     src/MainWindow.cpp
     src/MainWindow.h
+    src/AuthErrorNotification.cpp
+    src/AuthErrorNotification.h
     src/resources.qrc
 )
 
@@ -64,6 +66,7 @@ add_executable(TestMainWindow
     src/MainWindow.cpp
     src/GitHubClient.cpp
     src/SettingsDialog.cpp
+    src/AuthErrorNotification.cpp
     src/resources.qrc
 )
 

--- a/src/AuthErrorNotification.cpp
+++ b/src/AuthErrorNotification.cpp
@@ -1,0 +1,58 @@
+#include "AuthErrorNotification.h"
+#include <QStyle>
+#include <QApplication>
+
+AuthErrorNotification::AuthErrorNotification(QWidget *parent) : QWidget(parent) {
+    // Set window flags for a tooltip-like, topmost, frameless window
+    setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Tool);
+    setAttribute(Qt::WA_ShowWithoutActivating);
+    setAttribute(Qt::WA_DeleteOnClose, false); // We manage showing/hiding
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(10, 10, 10, 10);
+    mainLayout->setSpacing(5);
+
+    // Message Label
+    messageLabel = new QLabel(this);
+    messageLabel->setWordWrap(true);
+    messageLabel->setStyleSheet("color: white; font-weight: bold;");
+    mainLayout->addWidget(messageLabel);
+
+    // Buttons Layout
+    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    buttonLayout->setSpacing(10);
+    buttonLayout->addStretch();
+
+    settingsButton = new QPushButton("Settings", this);
+    settingsButton->setStyleSheet("background-color: #4CAF50; color: white; border: none; padding: 5px 10px; border-radius: 3px;");
+    connect(settingsButton, &QPushButton::clicked, this, &AuthErrorNotification::onSettingsClicked);
+    buttonLayout->addWidget(settingsButton);
+
+    dismissButton = new QPushButton("Dismiss", this);
+    dismissButton->setStyleSheet("background-color: #f44336; color: white; border: none; padding: 5px 10px; border-radius: 3px;");
+    connect(dismissButton, &QPushButton::clicked, this, &AuthErrorNotification::onDismissClicked);
+    buttonLayout->addWidget(dismissButton);
+
+    mainLayout->addLayout(buttonLayout);
+
+    // General styling
+    setStyleSheet("AuthErrorNotification { background-color: #333; border: 1px solid #555; border-radius: 5px; }");
+
+    // Set fixed width to avoid being too wide or narrow
+    setFixedWidth(300);
+}
+
+void AuthErrorNotification::setMessage(const QString &message) {
+    messageLabel->setText(message);
+    adjustSize();
+}
+
+void AuthErrorNotification::onSettingsClicked() {
+    emit settingsClicked();
+    close();
+}
+
+void AuthErrorNotification::onDismissClicked() {
+    emit dismissed();
+    close();
+}

--- a/src/AuthErrorNotification.h
+++ b/src/AuthErrorNotification.h
@@ -1,0 +1,31 @@
+#ifndef AUTHERRORNOTIFICATION_H
+#define AUTHERRORNOTIFICATION_H
+
+#include <QWidget>
+#include <QLabel>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+
+class AuthErrorNotification : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit AuthErrorNotification(QWidget *parent = nullptr);
+    void setMessage(const QString &message);
+
+signals:
+    void settingsClicked();
+    void dismissed();
+
+private slots:
+    void onSettingsClicked();
+    void onDismissClicked();
+
+private:
+    QLabel *messageLabel;
+    QPushButton *settingsButton;
+    QPushButton *dismissButton;
+};
+
+#endif // AUTHERRORNOTIFICATION_H

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -10,6 +10,7 @@
 #include <QLabel>
 #include <QPushButton>
 #include "GitHubClient.h"
+#include "AuthErrorNotification.h"
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -23,6 +24,7 @@ public:
     QWidget* getErrorPage() const { return errorPage; }
     QListWidget* getNotificationList() const { return notificationList; }
     QWidget* getLoginPage() const { return loginPage; }
+    AuthErrorNotification* getAuthNotification() const { return authNotification; }
 
 public slots:
     void updateNotifications(const QList<Notification> &notifications);
@@ -36,6 +38,7 @@ private slots:
     void showSettings();
     void showContextMenu(const QPoint &pos);
     void dismissCurrentItem();
+    void onAuthNotificationSettingsClicked();
 
 protected:
     void closeEvent(QCloseEvent *event) override;
@@ -65,6 +68,9 @@ private:
     QWidget *loginPage;
     QLabel *loginLabel;
     QPushButton *loginButton;
+
+    // Custom notification
+    AuthErrorNotification *authNotification;
 };
 
 #endif // MAINWINDOW_H

--- a/tests/TestMainWindow.cpp
+++ b/tests/TestMainWindow.cpp
@@ -4,6 +4,7 @@
 #include "../src/MainWindow.h"
 #include "../src/GitHubClient.h"
 #include "../src/SettingsDialog.h"
+#include "../src/AuthErrorNotification.h"
 
 class TestMainWindow : public QObject {
     Q_OBJECT
@@ -78,6 +79,23 @@ private slots:
 
         // Should switch back to notification list
         QCOMPARE(w.getStackWidget()->currentWidget(), w.getNotificationList());
+    }
+
+    void testAuthNotificationShown() {
+        QSettings settings;
+        settings.setValue("token", "dummy_token");
+
+        MainWindow w;
+        GitHubClient client;
+        w.setClient(&client);
+
+        // Trigger Auth Error
+        emit client.authError("Notification Test Error");
+
+        // Verify notification is created and shown
+        AuthErrorNotification *notif = w.getAuthNotification();
+        QVERIFY(notif != nullptr);
+        QVERIFY(notif->isVisible());
     }
 };
 


### PR DESCRIPTION
This PR replaces the native system tray notification for authentication errors with a custom `AuthErrorNotification` widget. The native notification did not support interactive buttons (like "Settings"), leading to user confusion when clicking it did nothing. The new notification includes a "Settings" button that directly opens the settings dialog, and a "Dismiss" button. It is positioned near the system tray icon or falls back to the bottom right of the screen. A new test case `testAuthNotificationShown` has been added to `TestMainWindow`.

---
*PR created automatically by Jules for task [11116471800477997971](https://jules.google.com/task/11116471800477997971) started by @arran4*