### PR TITLE
Enhance system tray context menu with Force Refresh and Open options

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -111,13 +111,23 @@ void MainWindow::setClient(GitHubClient *c) {
 void MainWindow::createTrayIcon() {
     trayIconMenu = new QMenu(this);
 
-    QAction *showAction = new QAction("Show", this);
-    connect(showAction, &QAction::triggered, this, &QWidget::showNormal);
-    trayIconMenu->addAction(showAction);
+    QAction *openAction = new QAction("Open", this);
+    connect(openAction, &QAction::triggered, this, &QWidget::showNormal);
+    trayIconMenu->addAction(openAction);
+
+    QAction *refreshAction = new QAction("Force Refresh", this);
+    connect(refreshAction, &QAction::triggered, [this]() {
+        if (client) {
+            client->checkNotifications();
+        }
+    });
+    trayIconMenu->addAction(refreshAction);
 
     QAction *settingsAction = new QAction("Settings", this);
     connect(settingsAction, &QAction::triggered, this, &MainWindow::showSettings);
     trayIconMenu->addAction(settingsAction);
+
+    trayIconMenu->addSeparator();
 
     QAction *quitAction = new QAction("Quit", this);
     connect(quitAction, &QAction::triggered, qApp, &QApplication::quit);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -25,6 +25,7 @@ public:
     QListWidget* getNotificationList() const { return notificationList; }
     QWidget* getLoginPage() const { return loginPage; }
     AuthErrorNotification* getAuthNotification() const { return authNotification; }
+    QMenu* getTrayIconMenu() const { return trayIconMenu; }
 
 public slots:
     void updateNotifications(const QList<Notification> &notifications);

--- a/tests/TestMainWindow.cpp
+++ b/tests/TestMainWindow.cpp
@@ -97,6 +97,25 @@ private slots:
         QVERIFY(notif != nullptr);
         QVERIFY(notif->isVisible());
     }
+
+    void testTrayMenuStructure() {
+        MainWindow w;
+        GitHubClient client;
+        w.setClient(&client);
+
+        QMenu *menu = w.getTrayIconMenu();
+        QVERIFY(menu != nullptr);
+
+        QList<QAction*> actions = menu->actions();
+        // Open, Force Refresh, Settings, Separator, Quit
+        QCOMPARE(actions.count(), 5);
+
+        QCOMPARE(actions[0]->text(), "Open");
+        QCOMPARE(actions[1]->text(), "Force Refresh");
+        QCOMPARE(actions[2]->text(), "Settings");
+        QVERIFY(actions[3]->isSeparator());
+        QCOMPARE(actions[4]->text(), "Quit");
+    }
 };
 
 QTEST_MAIN(TestMainWindow)


### PR DESCRIPTION
Updated the system tray context menu to include "Open", "Force Refresh", "Settings", and "Quit" options. The "Force Refresh" action allows users to manually trigger a notification check. A separator was added before "Quit" for better visual organization. A unit test was added to verify the menu structure.

---
*PR created automatically by Jules for task [16200688246736589001](https://jules.google.com/task/16200688246736589001) started by @arran4*