### PR TITLE
Add desktop file and installation rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(Kgithub-notify)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -62,3 +64,18 @@ target_link_libraries(TestAuth
 )
 
 add_test(NAME TestAuth COMMAND TestAuth)
+
+# Installation
+install(TARGETS Kgithub-notify
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    BUNDLE DESTINATION .
+)
+
+install(FILES kgithub-notify.desktop
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/applications
+)
+
+install(FILES src/assets/icon.png
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/1024x1024/apps
+    RENAME kgithub-notify.png
+)

--- a/kgithub-notify.desktop
+++ b/kgithub-notify.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=KGitHub Notify
+Comment=GitHub Notification System Tray
+Exec=Kgithub-notify
+Icon=kgithub-notify
+Type=Application
+Categories=Development;Utility;Qt;KDE;
+StartupWMClass=Kgithub-notify
+Terminal=false
+X-KDE-autostart-after=panel


### PR DESCRIPTION
This PR adds a `.desktop` file for better desktop integration, specifically targeting KDE with `X-KDE-autostart-after=panel`. It also updates `CMakeLists.txt` to include standard installation rules using `GNUInstallDirs`, installing the binary, the desktop file, and the application icon to their respective standard locations.

---
*PR created automatically by Jules for task [7313065827848378550](https://jules.google.com/task/7313065827848378550) started by @arran4*