### PR TITLE
Fix clang-format failures

### DIFF
--- a/src/AuthErrorNotification.cpp
+++ b/src/AuthErrorNotification.cpp
@@ -1,12 +1,13 @@
 #include "AuthErrorNotification.h"
-#include <QStyle>
+
 #include <QApplication>
+#include <QStyle>
 
 AuthErrorNotification::AuthErrorNotification(QWidget *parent) : QWidget(parent) {
     // Set window flags for a tooltip-like, topmost, frameless window
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Tool);
     setAttribute(Qt::WA_ShowWithoutActivating);
-    setAttribute(Qt::WA_DeleteOnClose, false); // We manage showing/hiding
+    setAttribute(Qt::WA_DeleteOnClose, false);  // We manage showing/hiding
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
     mainLayout->setContentsMargins(10, 10, 10, 10);
@@ -24,12 +25,14 @@ AuthErrorNotification::AuthErrorNotification(QWidget *parent) : QWidget(parent) 
     buttonLayout->addStretch();
 
     settingsButton = new QPushButton("Settings", this);
-    settingsButton->setStyleSheet("background-color: #4CAF50; color: white; border: none; padding: 5px 10px; border-radius: 3px;");
+    settingsButton->setStyleSheet(
+        "background-color: #4CAF50; color: white; border: none; padding: 5px 10px; border-radius: 3px;");
     connect(settingsButton, &QPushButton::clicked, this, &AuthErrorNotification::onSettingsClicked);
     buttonLayout->addWidget(settingsButton);
 
     dismissButton = new QPushButton("Dismiss", this);
-    dismissButton->setStyleSheet("background-color: #f44336; color: white; border: none; padding: 5px 10px; border-radius: 3px;");
+    dismissButton->setStyleSheet(
+        "background-color: #f44336; color: white; border: none; padding: 5px 10px; border-radius: 3px;");
     connect(dismissButton, &QPushButton::clicked, this, &AuthErrorNotification::onDismissClicked);
     buttonLayout->addWidget(dismissButton);
 

--- a/src/AuthErrorNotification.h
+++ b/src/AuthErrorNotification.h
@@ -1,31 +1,31 @@
 #ifndef AUTHERRORNOTIFICATION_H
 #define AUTHERRORNOTIFICATION_H
 
-#include <QWidget>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
 #include <QVBoxLayout>
-#include <QHBoxLayout>
+#include <QWidget>
 
 class AuthErrorNotification : public QWidget {
     Q_OBJECT
 
-public:
+   public:
     explicit AuthErrorNotification(QWidget *parent = nullptr);
     void setMessage(const QString &message);
 
-signals:
+   signals:
     void settingsClicked();
     void dismissed();
 
-private slots:
+   private slots:
     void onSettingsClicked();
     void onDismissClicked();
 
-private:
+   private:
     QLabel *messageLabel;
     QPushButton *settingsButton;
     QPushButton *dismissButton;
 };
 
-#endif // AUTHERRORNOTIFICATION_H
+#endif  // AUTHERRORNOTIFICATION_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,8 @@
 #include <QApplication>
 #include <QTimer>
-#include "MainWindow.h"
+
 #include "GitHubClient.h"
+#include "MainWindow.h"
 
 int main(int argc, char *argv[]) {
     QApplication app(argc, argv);

--- a/tests/TestAuth.cpp
+++ b/tests/TestAuth.cpp
@@ -1,12 +1,13 @@
-#include <QTest>
-#include <QSignalSpy>
 #include <QProcess>
+#include <QSignalSpy>
+#include <QTest>
+
 #include "../src/GitHubClient.h"
 
 class TestAuth : public QObject {
     Q_OBJECT
 
-private slots:
+   private slots:
     void initTestCase() {
         // Write python script
         QFile scriptFile("server.py");
@@ -46,7 +47,7 @@ private slots:
 
     void testAuthError401() {
         GitHubClient client;
-        client.setToken("invalid_token"); // Must set token so it doesn't fail with "No token provided"
+        client.setToken("invalid_token");  // Must set token so it doesn't fail with "No token provided"
         client.setApiUrl(QString("http://localhost:%1").arg(serverPort));
 
         QSignalSpy spy(&client, &GitHubClient::authError);
@@ -78,7 +79,7 @@ private slots:
         QCOMPARE(spy.takeFirst().at(0).toString(), QString("No token provided"));
     }
 
-private:
+   private:
     QProcess *serverProcess;
     int serverPort;
 };

--- a/tests/TestMain.cpp
+++ b/tests/TestMain.cpp
@@ -1,13 +1,14 @@
-#include <QTest>
-#include <QSignalSpy>
 #include <QSettings>
+#include <QSignalSpy>
+#include <QTest>
+
 #include "../src/GitHubClient.h"
 #include "../src/SettingsDialog.h"
 
 class TestGitHubClient : public QObject {
     Q_OBJECT
 
-private slots:
+   private slots:
     void initTestCase() {
         // Setup settings for testing
         QCoreApplication::setOrganizationName("Kgithub-notify-test");
@@ -16,7 +17,7 @@ private slots:
 
     void testConstruction() {
         GitHubClient client;
-        QVERIFY(true); // Just verifying it constructs without crash
+        QVERIFY(true);  // Just verifying it constructs without crash
     }
 
     void testTokenHandling() {


### PR DESCRIPTION
Applied clang-format to fix linting errors in `src/AuthErrorNotification.cpp`, `src/AuthErrorNotification.h`, `src/main.cpp`, `tests/TestAuth.cpp`, and `tests/TestMain.cpp`.

This ensures the codebase adheres to the project's style guidelines (Google style) and passes the `lint-and-fmt` CI job.

Verified by running `clang-format` locally and building the project/running tests to ensure no regressions.

---
*PR created automatically by Jules for task [3042347615212420547](https://jules.google.com/task/3042347615212420547) started by @arran4*