### PR TITLE
Use KWallet for token storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 find_package(Qt5 COMPONENTS Widgets Network Test REQUIRED)
+find_package(KF5Wallet REQUIRED)
 
 add_executable(Kgithub-notify
     src/main.cpp
@@ -30,6 +31,7 @@ add_executable(Kgithub-notify
 target_link_libraries(Kgithub-notify
     Qt5::Widgets
     Qt5::Network
+    KF5::Wallet
 )
 
 enable_testing()
@@ -47,6 +49,7 @@ target_link_libraries(TestMain
     Qt5::Widgets
     Qt5::Network
     Qt5::Test
+    KF5::Wallet
 )
 
 add_test(NAME TestMain COMMAND TestMain)
@@ -61,6 +64,7 @@ target_link_libraries(TestAuth
     Qt5::Widgets
     Qt5::Network
     Qt5::Test
+    KF5::Wallet
 )
 
 add_test(NAME TestAuth COMMAND TestAuth)

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -2,9 +2,9 @@
 #include <QVBoxLayout>
 #include <QLabel>
 #include <QPushButton>
-#include <QSettings>
 #include <QHBoxLayout>
 #include <QCoreApplication>
+#include <KWallet>
 
 SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent) {
     setWindowTitle("Settings");
@@ -35,12 +35,29 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent) {
 }
 
 void SettingsDialog::saveSettings() {
-    QSettings settings;
-    settings.setValue("token", tokenEdit->text());
+    KWallet::Wallet *wallet = KWallet::Wallet::openWallet(KWallet::Wallet::LocalWallet(), 0, KWallet::Wallet::Synchronous);
+    if (wallet) {
+        if (!wallet->hasFolder("Kgithub-notify")) {
+             wallet->createFolder("Kgithub-notify");
+        }
+        wallet->setFolder("Kgithub-notify");
+        wallet->writePassword("token", tokenEdit->text());
+        delete wallet;
+    }
     accept();
 }
 
 QString SettingsDialog::getToken() {
-    QSettings settings;
-    return settings.value("token").toString();
+    KWallet::Wallet *wallet = KWallet::Wallet::openWallet(KWallet::Wallet::LocalWallet(), 0, KWallet::Wallet::Synchronous);
+    if (wallet) {
+        if (!wallet->hasFolder("Kgithub-notify")) {
+             wallet->createFolder("Kgithub-notify");
+        }
+        wallet->setFolder("Kgithub-notify");
+        QString token;
+        wallet->readPassword("token", token);
+        delete wallet;
+        return token;
+    }
+    return QString();
 }

--- a/tests/TestMain.cpp
+++ b/tests/TestMain.cpp
@@ -1,4 +1,3 @@
-#include <QSettings>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -20,19 +19,6 @@ class TestGitHubClient : public QObject {
         QVERIFY(true);  // Just verifying it constructs without crash
     }
 
-    void testTokenHandling() {
-        // Since setToken is a setter without getter, we can't easily verify state without modifying class.
-        // However, we can verify SettingsDialog persistence.
-
-        QSettings settings("Kgithub-notify-test", "Kgithub-notify-test");
-        settings.clear();
-
-        QString testToken = "ghp_test12345";
-        settings.setValue("token", testToken);
-
-        // Check if SettingsDialog reads it correctly
-        QCOMPARE(SettingsDialog::getToken(), testToken);
-    }
 
     void testUrlConversion() {
         // Issue


### PR DESCRIPTION
This PR updates the application to store the GitHub Personal Access Token in KWallet instead of using QSettings (plaintext). This enhances security by leveraging the system's wallet service.

Changes:
- `CMakeLists.txt`: Added `KF5Wallet` dependency.
- `src/SettingsDialog.cpp`: Implemented `getToken` and `saveSettings` using `KWallet::Wallet`.
- `tests/TestMain.cpp`: Removed the test that verified QSettings persistence.

Note: This change requires `libkf5wallet-dev` and a working KWallet environment. Tests relying on token persistence are skipped/removed in headless environments where KWallet might not be available.


---
*PR created automatically by Jules for task [17859039647770940925](https://jules.google.com/task/17859039647770940925) started by @arran4*