### PR TITLE
Add Test Key and Configurable Interval to Settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,20 @@ target_link_libraries(TestAuth
 
 add_test(NAME TestAuth COMMAND TestAuth)
 
+add_executable(TestVerifyToken
+    tests/TestVerifyToken.cpp
+    src/GitHubClient.cpp
+)
+
+target_link_libraries(TestVerifyToken
+    Qt5::Widgets
+    Qt5::Network
+    Qt5::Test
+    KF5::Wallet
+)
+
+add_test(NAME TestVerifyToken COMMAND TestVerifyToken)
+
 # Installation
 install(TARGETS Kgithub-notify
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/GitHubClient.h
+++ b/src/GitHubClient.h
@@ -27,12 +27,14 @@ public:
     void setToken(const QString &token);
     void setApiUrl(const QString &url);
     void checkNotifications();
+    void verifyToken();
     void markAsRead(const QString &id);
 
 signals:
     void notificationsReceived(const QList<Notification> &notifications);
     void errorOccurred(const QString &error);
     void authError(const QString &message);
+    void tokenVerified(bool valid, const QString &message);
 
 private slots:
     void onReplyFinished(QNetworkReply *reply);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -188,7 +188,8 @@ void MainWindow::setClient(GitHubClient *c) {
 
     if (refreshTimer) {
         connect(refreshTimer, &QTimer::timeout, client, &GitHubClient::checkNotifications);
-        refreshTimer->setInterval(300000); // 5 minutes
+        int interval = SettingsDialog::getInterval();
+        refreshTimer->setInterval(interval * 60 * 1000);
         refreshTimer->start();
     }
 
@@ -360,9 +361,15 @@ void MainWindow::showSettings() {
     SettingsDialog dialog(this);
     if (dialog.exec() == QDialog::Accepted) {
         QString newToken = dialog.getToken();
+        int interval = SettingsDialog::getInterval();
         if (client) {
             client->setToken(newToken);
             client->checkNotifications(); // Force check immediately
+        }
+        if (refreshTimer) {
+            refreshTimer->setInterval(interval * 60 * 1000);
+            refreshTimer->start();
+            updateStatusBar();
         }
     }
 }

--- a/src/SettingsDialog.h
+++ b/src/SettingsDialog.h
@@ -4,17 +4,29 @@
 #include <QDialog>
 #include <QLineEdit>
 
+class QComboBox;
+class QPushButton;
+class QLabel;
+class GitHubClient;
+
 class SettingsDialog : public QDialog {
     Q_OBJECT
 public:
     explicit SettingsDialog(QWidget *parent = nullptr);
     static QString getToken();
+    static int getInterval();
 
 private slots:
     void saveSettings();
+    void onTestClicked();
+    void onVerificationResult(bool valid, const QString &message);
 
 private:
     QLineEdit *tokenEdit;
+    QComboBox *intervalCombo;
+    QPushButton *testButton;
+    QLabel *statusLabel;
+    GitHubClient *testClient;
 };
 
 #endif // SETTINGSDIALOG_H

--- a/tests/TestVerifyToken.cpp
+++ b/tests/TestVerifyToken.cpp
@@ -1,0 +1,83 @@
+#include <QProcess>
+#include <QSignalSpy>
+#include <QTest>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QApplication>
+
+#include "../src/GitHubClient.h"
+
+class TestVerifyToken : public QObject {
+    Q_OBJECT
+
+   private slots:
+    void initTestCase() {
+        // Setup simple HTTP server in Python
+        QFile scriptFile("verify_server.py");
+        if (scriptFile.open(QIODevice::WriteOnly)) {
+            QTextStream out(&scriptFile);
+            out << "import http.server, socketserver, json\n"
+                << "class Handler(http.server.BaseHTTPRequestHandler):\n"
+                << "    def do_GET(self):\n"
+                << "        if self.path == '/user':\n"
+                << "            self.send_response(200)\n"
+                << "            self.send_header('Content-type', 'application/json')\n"
+                << "            self.end_headers()\n"
+                << "            self.wfile.write(json.dumps({'login': 'testuser'}).encode())\n"
+                << "        else:\n"
+                << "            self.send_response(404)\n"
+                << "            self.end_headers()\n"
+                << "\n"
+                << "with socketserver.TCPServer(('', 0), Handler) as httpd:\n"
+                << "    print(httpd.server_address[1], flush=True)\n"
+                << "    httpd.serve_forever()\n";
+            scriptFile.close();
+        }
+
+        serverProcess = new QProcess(this);
+        serverProcess->start("python3", QStringList() << "-u" << "verify_server.py");
+
+        QVERIFY(serverProcess->waitForStarted());
+        if (!serverProcess->waitForReadyRead(5000)) {
+            QFAIL("Server failed to start");
+        }
+        QByteArray portData = serverProcess->readLine().trimmed();
+        serverPort = portData.toInt();
+        QVERIFY(serverPort > 0);
+    }
+
+    void cleanupTestCase() {
+        if (serverProcess) {
+            serverProcess->terminate();
+            serverProcess->waitForFinished();
+        }
+    }
+
+    void testVerifyTokenSuccess() {
+        GitHubClient client;
+        client.setToken("valid_token");
+        QString url = QString("http://localhost:%1").arg(serverPort);
+        client.setApiUrl(url);
+
+        QSignalSpy spy(&client, &GitHubClient::tokenVerified);
+
+        client.verifyToken();
+
+        QVERIFY2(spy.wait(5000), "Timeout waiting for tokenVerified signal");
+        QCOMPARE(spy.count(), 1);
+
+        QList<QVariant> args = spy.takeFirst();
+        bool valid = args.at(0).toBool();
+        QString message = args.at(1).toString();
+
+        QVERIFY2(valid, "Token should be verified as valid");
+        QVERIFY2(message.contains("testuser"), "Message should contain username 'testuser'");
+    }
+
+   private:
+    QProcess *serverProcess;
+    int serverPort;
+};
+
+QTEST_MAIN(TestVerifyToken)
+#include "TestVerifyToken.moc"


### PR DESCRIPTION
This PR adds two requested features to the Settings page:
1.  **Test Key**: A button to verify the validity of the Personal Access Token. It queries the GitHub API (`/user`) and displays the result (success with username or failure with error message).
2.  **Configurable Interval**: A dropdown to select the polling interval for notifications, replacing the hardcoded 5-minute interval. The setting is saved and applied immediately.

A new unit test `TestVerifyToken` was added to ensure the verification logic works correctly.

---
*PR created automatically by Jules for task [2530902474310086766](https://jules.google.com/task/2530902474310086766) started by @arran4*