### PR TITLE
Implement interactive NotificationPopup with summary and action buttons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ add_executable(Kgithub-notify
     src/MainWindow.h
     src/AuthErrorNotification.cpp
     src/AuthErrorNotification.h
+    src/NotificationPopup.cpp
+    src/NotificationPopup.h
     src/NotificationItemWidget.cpp
     src/NotificationItemWidget.h
     src/resources.qrc

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -14,11 +14,13 @@
 #include <QTimer>
 #include "GitHubClient.h"
 #include "AuthErrorNotification.h"
+#include "NotificationPopup.h"
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
 public:
     explicit MainWindow(QWidget *parent = nullptr);
+    ~MainWindow();
     void showTrayMessage(const QString &title, const QString &message);
     void setClient(GitHubClient *client);
 
@@ -52,6 +54,7 @@ protected:
 
 private:
     void createTrayIcon();
+    void positionPopup(QWidget *popup);
     void createErrorPage();
     void createLoginPage();
     void createEmptyStatePage();
@@ -94,6 +97,7 @@ private:
 
     // Custom notification
     AuthErrorNotification *authNotification;
+    NotificationPopup *notificationPopup;
 
     // Status Bar
     QStatusBar *statusBar;

--- a/src/NotificationPopup.cpp
+++ b/src/NotificationPopup.cpp
@@ -1,0 +1,98 @@
+#include "NotificationPopup.h"
+#include <QApplication>
+#include <QStyle>
+#include <QDesktopServices>
+#include <QUrl>
+
+NotificationPopup::NotificationPopup(QWidget *parent) : QWidget(parent) {
+    setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Tool);
+    setAttribute(Qt::WA_ShowWithoutActivating);
+    setAttribute(Qt::WA_DeleteOnClose, false);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(10, 10, 10, 10);
+    mainLayout->setSpacing(5);
+
+    // Title Label
+    titleLabel = new QLabel(this);
+    titleLabel->setStyleSheet("color: white; font-weight: bold; font-size: 14px;");
+    mainLayout->addWidget(titleLabel);
+
+    // Message Label
+    messageLabel = new QLabel(this);
+    messageLabel->setWordWrap(true);
+    messageLabel->setStyleSheet("color: white;");
+    mainLayout->addWidget(messageLabel);
+
+    // Buttons Layout
+    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    buttonLayout->setSpacing(10);
+    buttonLayout->addStretch();
+
+    openButton = new QPushButton("Open", this);
+    openButton->setStyleSheet(
+        "background-color: #2196F3; color: white; border: none; padding: 5px 10px; border-radius: 3px;");
+    connect(openButton, &QPushButton::clicked, this, &NotificationPopup::onOpenClicked);
+    buttonLayout->addWidget(openButton);
+
+    clientButton = new QPushButton("Open Client", this);
+    clientButton->setStyleSheet(
+        "background-color: #4CAF50; color: white; border: none; padding: 5px 10px; border-radius: 3px;");
+    connect(clientButton, &QPushButton::clicked, this, &NotificationPopup::onClientClicked);
+    buttonLayout->addWidget(clientButton);
+
+    dismissButton = new QPushButton("Dismiss", this);
+    dismissButton->setStyleSheet(
+        "background-color: #f44336; color: white; border: none; padding: 5px 10px; border-radius: 3px;");
+    connect(dismissButton, &QPushButton::clicked, this, &NotificationPopup::onDismissClicked);
+    buttonLayout->addWidget(dismissButton);
+
+    mainLayout->addLayout(buttonLayout);
+
+    setStyleSheet("NotificationPopup { background-color: #333; border: 1px solid #555; border-radius: 5px; }");
+    setFixedWidth(350);
+
+    // Auto-close timer
+    autoCloseTimer = new QTimer(this);
+    autoCloseTimer->setSingleShot(true);
+    connect(autoCloseTimer, &QTimer::timeout, this, &NotificationPopup::onDismissClicked);
+}
+
+void NotificationPopup::setTitle(const QString &title) {
+    titleLabel->setText(title);
+}
+
+void NotificationPopup::setMessage(const QString &message) {
+    messageLabel->setText(message);
+    adjustSize();
+    // Restart timer when content changes
+    autoCloseTimer->start(10000); // 10 seconds
+}
+
+void NotificationPopup::setOpenUrl(const QString &url) {
+    currentUrl = url;
+}
+
+void NotificationPopup::showOpenButton(bool show) {
+    openButton->setVisible(show);
+}
+
+void NotificationPopup::onOpenClicked() {
+    autoCloseTimer->stop();
+    if (!currentUrl.isEmpty()) {
+        emit openUrlClicked(currentUrl);
+    }
+    close();
+}
+
+void NotificationPopup::onClientClicked() {
+    autoCloseTimer->stop();
+    emit openClientClicked();
+    close();
+}
+
+void NotificationPopup::onDismissClicked() {
+    autoCloseTimer->stop();
+    emit dismissed();
+    close();
+}

--- a/src/NotificationPopup.h
+++ b/src/NotificationPopup.h
@@ -1,0 +1,41 @@
+#ifndef NOTIFICATIONPOPUP_H
+#define NOTIFICATIONPOPUP_H
+
+#include <QWidget>
+#include <QLabel>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QTimer>
+
+class NotificationPopup : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit NotificationPopup(QWidget *parent = nullptr);
+    void setTitle(const QString &title);
+    void setMessage(const QString &message);
+    void setOpenUrl(const QString &url);
+    void showOpenButton(bool show);
+
+signals:
+    void openUrlClicked(const QString &url);
+    void openClientClicked();
+    void dismissed();
+
+private slots:
+    void onOpenClicked();
+    void onClientClicked();
+    void onDismissClicked();
+
+private:
+    QLabel *titleLabel;
+    QLabel *messageLabel;
+    QPushButton *openButton;
+    QPushButton *clientButton;
+    QPushButton *dismissButton;
+    QString currentUrl;
+    QTimer *autoCloseTimer;
+};
+
+#endif // NOTIFICATIONPOPUP_H


### PR DESCRIPTION
Replaced the standard system tray notification messages with a custom `NotificationPopup` widget. This new widget provides a richer user experience by showing a summary of notifications when multiple are present, and a direct "Open" button when only a single notification arrives. It also includes an "Open Client" button to easily access the main application window. The popup is positioned near the system tray or in the bottom-right corner if the tray is not available. This change addresses the user request for better notification summaries and interactive options.

---
*PR created automatically by Jules for task [1943123465969551386](https://jules.google.com/task/1943123465969551386) started by @arran4*