### PR TITLE
Enhance notification items with rich links and author details

### DIFF
--- a/src/GitHubClient.h
+++ b/src/GitHubClient.h
@@ -29,12 +29,14 @@ public:
     void checkNotifications();
     void verifyToken();
     void markAsRead(const QString &id);
+    void fetchSubjectDetails(const QString &apiUrl, const QString &notificationId);
 
 signals:
     void notificationsReceived(const QList<Notification> &notifications);
     void errorOccurred(const QString &error);
     void authError(const QString &message);
     void tokenVerified(bool valid, const QString &message);
+    void subjectDetailsReceived(const QString &notificationId, const QString &details);
 
 private slots:
     void onReplyFinished(QNetworkReply *reply);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -26,11 +26,13 @@ public slots:
     void updateNotifications(const QList<Notification> &notifications);
     void showError(const QString &error);
     void onAuthError(const QString &message);
+    void onSubjectDetailsReceived(const QString &id, const QString &details);
 
 private slots:
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
     void onTrayMessageClicked();
     void onNotificationItemActivated(QListWidgetItem *item);
+    void onItemLinkActivated(const QString &id, const QString &apiUrl, const QString &htmlUrl);
     void showSettings();
     void showContextMenu(const QPoint &pos);
     void dismissCurrentItem();

--- a/src/NotificationItemWidget.h
+++ b/src/NotificationItemWidget.h
@@ -19,11 +19,17 @@ public:
     QLabel *typeLabel;
     QLabel *dateLabel;
     QLabel *urlLabel;
+    QLabel *authorLabel;
 
     QString getTitle() const { return titleLabel->text(); }
+    void setDetails(const QString &details);
 
 signals:
-    // No specific signals yet
+    void linkActivated(const QString &id, const QString &apiUrl, const QString &htmlUrl);
+
+private:
+    QString m_notificationId;
+    QString m_apiUrl;
 };
 
 #endif // NOTIFICATIONITEMWIDGET_H


### PR DESCRIPTION
This change improves the notification list by making the URL visually distinct and clickable (handling mark-as-read behavior correctly) and by fetching and displaying the author and assignees for each notification subject (Issue/PR). This provides more context to the user directly in the list.

---
*PR created automatically by Jules for task [715037458019285694](https://jules.google.com/task/715037458019285694) started by @arran4*