### PR TITLE
🔒 Fix HTML injection in NotificationItemWidget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,22 @@ target_link_libraries(TestVerifyToken
 
 add_test(NAME TestVerifyToken COMMAND TestVerifyToken)
 
+add_executable(TestNotificationWidget
+    tests/TestNotificationWidget.cpp
+    src/NotificationItemWidget.cpp
+    src/GitHubClient.cpp
+    src/SettingsDialog.cpp
+)
+
+target_link_libraries(TestNotificationWidget
+    Qt5::Widgets
+    Qt5::Network
+    Qt5::Test
+    KF5::Wallet
+)
+
+add_test(NAME TestNotificationWidget COMMAND TestNotificationWidget)
+
 # Installation
 install(TARGETS Kgithub-notify
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/NotificationItemWidget.cpp
+++ b/src/NotificationItemWidget.cpp
@@ -1,10 +1,13 @@
 #include "NotificationItemWidget.h"
-#include <QFont>
-#include <QDateTime>
-#include <QStyle>
-#include <QLocale>
 
-NotificationItemWidget::NotificationItemWidget(const Notification &n, QWidget *parent) : QWidget(parent) {
+#include <QDateTime>
+#include <QFont>
+#include <QLocale>
+#include <QStyle>
+
+NotificationItemWidget::NotificationItemWidget(const Notification &n,
+                                               QWidget *parent)
+    : QWidget(parent) {
     QHBoxLayout *mainLayout = new QHBoxLayout(this);
     mainLayout->setContentsMargins(5, 5, 5, 5);
 
@@ -15,6 +18,7 @@ NotificationItemWidget::NotificationItemWidget(const Notification &n, QWidget *p
 
     // Title
     titleLabel = new QLabel(n.title, this);
+    titleLabel->setTextFormat(Qt::PlainText);
     QFont titleFont = titleLabel->font();
     if (n.unread) {
         titleFont.setBold(true);
@@ -25,9 +29,11 @@ NotificationItemWidget::NotificationItemWidget(const Notification &n, QWidget *p
 
     // Repo and Type
     QHBoxLayout *repoTypeLayout = new QHBoxLayout();
-    repoLabel = new QLabel(QString("Repo: <b>%1</b>").arg(n.repository), this);
+    repoLabel = new QLabel(
+        QString("Repo: <b>%1</b>").arg(n.repository.toHtmlEscaped()), this);
     repoLabel->setTextFormat(Qt::RichText);
     typeLabel = new QLabel(QString("Type: %1").arg(n.type), this);
+    typeLabel->setTextFormat(Qt::PlainText);
 
     repoTypeLayout->addWidget(repoLabel);
     repoTypeLayout->addSpacing(10);
@@ -41,14 +47,18 @@ NotificationItemWidget::NotificationItemWidget(const Notification &n, QWidget *p
 
     // Parse date
     QDateTime dt = QDateTime::fromString(n.updatedAt, Qt::ISODate);
-    QString dateStr = dt.isValid() ? QLocale::system().toString(dt, QLocale::ShortFormat) : n.updatedAt;
+    QString dateStr = dt.isValid()
+                          ? QLocale::system().toString(dt, QLocale::ShortFormat)
+                          : n.updatedAt;
 
     dateLabel = new QLabel("Date: " + dateStr, this);
 
     QString htmlUrl = GitHubClient::apiToHtmlUrl(n.url);
     urlLabel = new QLabel(htmlUrl, this);
+    urlLabel->setTextFormat(Qt::PlainText);
     urlLabel->setWordWrap(true);
-    urlLabel->setTextInteractionFlags(Qt::TextSelectableByMouse); // Allow selection
+    urlLabel->setTextInteractionFlags(
+        Qt::TextSelectableByMouse);  // Allow selection
 
     dateUrlLayout->addWidget(dateLabel);
     dateUrlLayout->addSpacing(10);

--- a/tests/TestNotificationWidget.cpp
+++ b/tests/TestNotificationWidget.cpp
@@ -1,0 +1,84 @@
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QTest>
+#include <QVBoxLayout>
+
+#include "../src/GitHubClient.h"
+#include "../src/NotificationItemWidget.h"
+
+class TestNotificationWidget : public QObject {
+    Q_OBJECT
+
+private slots:
+    void testHtmlInjection() {
+        Notification n;
+        n.title = "<b>Title</b>";
+        n.type = "<b>Type</b>";
+        n.repository = "<b>Repo</b>";
+        n.url = "http://example.com";
+        n.updatedAt = "2023-01-01T00:00:00Z";
+        n.unread = true;
+
+        NotificationItemWidget widget(n);
+
+        // Find all QLabels
+        QList<QLabel*> labels = widget.findChildren<QLabel*>();
+
+        QLabel* repoLabel = nullptr;
+        QLabel* typeLabel = nullptr;
+        QLabel* titleLabel = nullptr;
+        QLabel* urlLabel = nullptr;
+
+        for (QLabel* label : labels) {
+            QString text = label->text();
+            if (text.startsWith("Repo: ")) {
+                repoLabel = label;
+            } else if (text.startsWith("Type: ")) {
+                typeLabel = label;
+            } else if (text == n.title) {
+                titleLabel = label;
+            } else if (text.contains("example.com")) {
+                urlLabel = label;
+            }
+        }
+
+        QVERIFY2(repoLabel != nullptr, "Repo label not found");
+        QVERIFY2(typeLabel != nullptr, "Type label not found");
+        // titleLabel and urlLabel might be found or not depending on processing
+
+        // Check Repo Label
+        // Current Vulnerable behavior: text is "Repo: <b><b>Repo</b></b>"
+        // Expected Fix: text should contain escaped HTML
+        // "&lt;b&gt;Repo&lt;/b&gt;"
+        QString repoText = repoLabel->text();
+
+        // This assertion will FAIL if the code is vulnerable (it contains
+        // <b>Repo</b>) And PASS if the code is fixed (it contains
+        // &lt;b&gt;Repo&lt;/b&gt;) Actually, to make the test FAIL on
+        // vulnerability, we assert the SAFE condition.
+        QVERIFY2(
+            repoText.contains("&lt;b&gt;Repo&lt;/b&gt;"),
+            qPrintable(
+                QString("Repository name should be HTML escaped. Actual: %1")
+                    .arg(repoText)));
+
+        // Check Type Label
+        // Vulnerable: AutoText (default)
+        // Fixed: PlainText
+        QCOMPARE(typeLabel->textFormat(), Qt::PlainText);
+
+        // Check Title Label
+        if (titleLabel) {
+            QCOMPARE(titleLabel->textFormat(), Qt::PlainText);
+        }
+
+        // Check URL Label
+        if (urlLabel) {
+            // URL label should also be PlainText
+            QCOMPARE(urlLabel->textFormat(), Qt::PlainText);
+        }
+    }
+};
+
+QTEST_MAIN(TestNotificationWidget)
+#include "TestNotificationWidget.moc"


### PR DESCRIPTION
🎯 **What:** Fixed an HTML injection vulnerability in `NotificationItemWidget` where user-controlled strings (repository name, type, title) could be rendered as HTML.
⚠️ **Risk:** If a malicious repository name or notification content contained HTML tags, they would be executed/rendered by the `QLabel` rich text engine. This could lead to UI spoofing or potentially worse if coupled with other vulnerabilities.
🛡️ **Solution:**
- Used `.toHtmlEscaped()` for the repository name which is displayed in a bold tag using `Qt::RichText`.
- Set `setTextFormat(Qt::PlainText)` for other labels (`titleLabel`, `typeLabel`, `urlLabel`) to ensure they are treated as raw text.
- Added a new unit test `TestNotificationWidget` to confirm the fix and prevent regressions.

---
*PR created automatically by Jules for task [17228660102222728430](https://jules.google.com/task/17228660102222728430) started by @arran4*