### PR TITLE
Fix system tray icon visibility with high-contrast SVGs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt5 COMPONENTS Widgets Network Test REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Network Svg Test REQUIRED)
 find_package(KF5Wallet REQUIRED)
 
 add_executable(Kgithub-notify
@@ -31,6 +31,7 @@ add_executable(Kgithub-notify
 target_link_libraries(Kgithub-notify
     Qt5::Widgets
     Qt5::Network
+    Qt5::Svg
     KF5::Wallet
 )
 
@@ -96,4 +97,9 @@ install(FILES kgithub-notify.desktop
 install(FILES src/assets/icon.png
     DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/1024x1024/apps
     RENAME kgithub-notify.png
+)
+
+install(FILES src/assets/icon.svg
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps
+    RENAME kgithub-notify.svg
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ target_link_libraries(TestVerifyToken
 
 add_test(NAME TestVerifyToken COMMAND TestVerifyToken)
 
+
 # Installation
 install(TARGETS Kgithub-notify
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -16,7 +16,7 @@
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), client(nullptr), pendingAuthError(false), authNotification(nullptr) {
     setWindowTitle("Kgithub-notify");
-    setWindowIcon(QIcon(":/assets/icon.png"));
+    setWindowIcon(QIcon(":/assets/icon.svg"));
     resize(400, 600);
 
     // Initialize Stacked Widget
@@ -227,7 +227,7 @@ void MainWindow::createTrayIcon() {
     trayIcon = new QSystemTrayIcon(this);
     trayIcon->setContextMenu(trayIconMenu);
 
-    QIcon icon(":/assets/icon.png");
+    QIcon icon(":/assets/icon.svg");
     if (icon.isNull()) {
         icon = QApplication::style()->standardIcon(QStyle::SP_ComputerIcon);
     }
@@ -299,12 +299,12 @@ void MainWindow::updateNotifications(const QList<Notification> &notifications) {
     }
 
     if (unreadCount > 0) {
-        trayIcon->setIcon(QIcon(":/assets/icon-dotted.png"));
+        trayIcon->setIcon(QIcon(":/assets/icon-dotted.svg"));
         if (newNotifications > 0) {
             showTrayMessage("GitHub Notifications", QString("You have %1 new notification(s)").arg(newNotifications));
         }
     } else {
-        QIcon icon(":/assets/icon.png");
+        QIcon icon(":/assets/icon.svg");
         if (icon.isNull()) {
             icon = QApplication::style()->standardIcon(QStyle::SP_ComputerIcon);
         }
@@ -458,7 +458,7 @@ void MainWindow::dismissCurrentItem() {
 
     // Update icon if list is empty
     if (notificationList->count() == 0) {
-        QIcon icon(":/assets/icon.png");
+        QIcon icon(":/assets/icon.svg");
         if (icon.isNull()) {
             icon = QApplication::style()->standardIcon(QStyle::SP_ComputerIcon);
         }
@@ -535,7 +535,7 @@ void MainWindow::onDismissSelectedClicked() {
 
     // Update icon if list is empty
     if (notificationList->count() == 0) {
-        QIcon icon(":/assets/icon.png");
+        QIcon icon(":/assets/icon.svg");
         if (icon.isNull()) {
             icon = QApplication::style()->standardIcon(QStyle::SP_ComputerIcon);
         }

--- a/src/assets/icon-dotted.svg
+++ b/src/assets/icon-dotted.svg
@@ -1,4 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-  <path fill="#ffffff" stroke="#000000" stroke-width="1.5" d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.63-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.64 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/>
-  <circle cx="18" cy="6" r="3" fill="#ff0000" stroke="#000000" stroke-width="1"/>
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <!-- Cat Face Silhouette -->
+  <path d="M 16 24 L 8 4 L 28 12 C 30 11 34 11 36 12 L 56 4 L 48 24 C 58 28 58 48 48 56 C 40 62 24 62 16 56 C 6 48 6 28 16 24 Z"
+        fill="white" stroke="black" stroke-width="3" stroke-linejoin="round" />
+  <!-- Eyes -->
+  <circle cx="24" cy="32" r="4" fill="black" />
+  <circle cx="40" cy="32" r="4" fill="black" />
+  <!-- Nose -->
+  <path d="M 32 42 L 28 38 L 36 38 Z" fill="black" />
+  <!-- Notification Indicator -->
+  <circle cx="54" cy="10" r="7" fill="#ff0000" stroke="white" stroke-width="2" />
 </svg>

--- a/src/assets/icon-dotted.svg
+++ b/src/assets/icon-dotted.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path fill="#ffffff" stroke="#000000" stroke-width="1.5" d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.63-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.64 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/>
+  <circle cx="18" cy="6" r="3" fill="#ff0000" stroke="#000000" stroke-width="1"/>
+</svg>

--- a/src/assets/icon.svg
+++ b/src/assets/icon.svg
@@ -1,3 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-  <path fill="#ffffff" stroke="#000000" stroke-width="1.5" d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.63-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.64 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/>
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <!-- Cat Face Silhouette -->
+  <path d="M 16 24 L 8 4 L 28 12 C 30 11 34 11 36 12 L 56 4 L 48 24 C 58 28 58 48 48 56 C 40 62 24 62 16 56 C 6 48 6 28 16 24 Z"
+        fill="white" stroke="black" stroke-width="3" stroke-linejoin="round" />
+  <!-- Eyes -->
+  <circle cx="24" cy="32" r="4" fill="black" />
+  <circle cx="40" cy="32" r="4" fill="black" />
+  <!-- Nose -->
+  <path d="M 32 42 L 28 38 L 36 38 Z" fill="black" />
 </svg>

--- a/src/assets/icon.svg
+++ b/src/assets/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path fill="#ffffff" stroke="#000000" stroke-width="1.5" d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.63-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.64 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/>
+</svg>

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -3,5 +3,7 @@
     <qresource prefix="/">
         <file>assets/icon.png</file>
         <file>assets/icon-dotted.png</file>
+        <file>assets/icon.svg</file>
+        <file>assets/icon-dotted.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Replaced the 1024x1024 PNG icons with scalable SVG icons designed for high contrast (white fill, black stroke). This ensures the system tray icon and notification indicator are visible on both light and dark themes. Updated the build system to include the Qt5 Svg module and install the scalable icon.

---
*PR created automatically by Jules for task [9367090029943631170](https://jules.google.com/task/9367090029943631170) started by @arran4*