### PR TITLE
🧪 Test SettingsDialog::getInterval

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,21 @@ target_link_libraries(TestAuth
 
 add_test(NAME TestAuth COMMAND TestAuth)
 
+add_executable(TestSettings
+    tests/TestSettings.cpp
+    src/GitHubClient.cpp
+    src/SettingsDialog.cpp
+)
+
+target_link_libraries(TestSettings
+    Qt5::Widgets
+    Qt5::Network
+    Qt5::Test
+    KF5::Wallet
+)
+
+add_test(NAME TestSettings COMMAND TestSettings)
+
 add_executable(TestVerifyToken
     tests/TestVerifyToken.cpp
     src/GitHubClient.cpp

--- a/tests/TestSettings.cpp
+++ b/tests/TestSettings.cpp
@@ -1,0 +1,31 @@
+#include <QTest>
+#include <QSettings>
+#include "../src/SettingsDialog.h"
+
+class TestSettings : public QObject {
+    Q_OBJECT
+
+private slots:
+    void initTestCase() {
+        QCoreApplication::setOrganizationName("Kgithub-notify-test");
+        QCoreApplication::setApplicationName("Kgithub-notify-test");
+    }
+
+    void init() {
+        QSettings settings;
+        settings.clear();
+    }
+
+    void testDefaultInterval() {
+        QCOMPARE(SettingsDialog::getInterval(), 5);
+    }
+
+    void testCustomInterval() {
+        QSettings settings;
+        settings.setValue("interval", 15);
+        QCOMPARE(SettingsDialog::getInterval(), 15);
+    }
+};
+
+QTEST_MAIN(TestSettings)
+#include "TestSettings.moc"


### PR DESCRIPTION
🎯 **What:** add a unit test for `SettingsDialog::getInterval` to ensure it correctly retrieves the refresh interval from `QSettings`.

📊 **Coverage:**
- Verifies that the default interval is 5 when no setting is present.
- Verifies that a custom interval (e.g., 15) is correctly retrieved when set.
- Uses `QCoreApplication::setOrganizationName("Kgithub-notify-test")` to isolate the test from the user's actual configuration.

✨ **Result:** Increased test coverage for the configuration logic, ensuring reliability of the settings retrieval.

---
*PR created automatically by Jules for task [15337888166393333996](https://jules.google.com/task/15337888166393333996) started by @arran4*