### PR TITLE
Enhance KDE-native integration for menus, icons, and settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(Kgithub-notify)
+project(Kgithub-notify VERSION 0.1.0)
 
 include(GNUInstallDirs)
 
@@ -59,6 +59,8 @@ target_link_libraries(Kgithub-notify
     KF5::Wallet
     KF5::Notifications
 )
+
+target_compile_definitions(Kgithub-notify PRIVATE KGHN_APP_VERSION="${PROJECT_VERSION}")
 
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A GitHub notification system tray application written in C++ using Qt5. It notif
 *   **System Tray Integration**: Runs in the background and sits in your system tray.
 *   **Periodic Polling**: Checks for new notifications every 5 minutes.
 *   **Desktop Notifications**: Shows system notifications when new items arrive.
+*   **KDE-First Integration**: Uses KWallet for token storage, KNotification for desktop alerts, KDE-themed icons, and quick links to KDE notification settings.
 *   **Quick Actions**:
     *   **Open**: Opens the notification URL in your default browser. This also marks the notification as read.
     *   **Copy Link**: Copies the link to the notification (without referrer ID) to your clipboard.

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -13,6 +13,9 @@
 #include <QStatusBar>
 #include <QTimer>
 #include <QFutureWatcher>
+#include <QIcon>
+#include <QStyle>
+#include <QStringList>
 #include "GitHubClient.h"
 #include "AuthErrorNotification.h"
 #include <KNotification>
@@ -55,6 +58,8 @@ private slots:
     void onDismissSelectedClicked();
     void onOpenSelectedClicked();
     void onToggleShowAll();
+    void showAboutDialog();
+    void openKdeNotificationSettings();
 
 protected:
     void closeEvent(QCloseEvent *event) override;
@@ -76,6 +81,8 @@ private:
     void setupMenus();
     void setupStatusBar();
     void loadToken();
+    QIcon themedIcon(const QStringList &names, const QString &fallbackResource = QString(),
+                     QStyle::StandardPixmap fallbackPixmap = QStyle::SP_FileIcon) const;
 
     QSystemTrayIcon *trayIcon;
     QMenu *trayIconMenu;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,11 +6,16 @@
 #include "GitHubClient.h"
 #include "MainWindow.h"
 
+#ifndef KGHN_APP_VERSION
+#define KGHN_APP_VERSION "dev"
+#endif
+
 int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
     QApplication::setOrganizationName("Kgithub-notify");
     QApplication::setApplicationName("kgithub-notify");
     QApplication::setDesktopFileName("kgithub-notify");
+    QApplication::setApplicationVersion(QStringLiteral(KGHN_APP_VERSION));
     QApplication::setQuitOnLastWindowClosed(false);
 
     QCommandLineParser parser;


### PR DESCRIPTION
### Motivation

- Improve the KDE/Plasma look-and-feel and user workflow by preferring theme icons, exposing KDE notification settings, and providing a richer About/Help UX. 
- Surface build-time application version at runtime so About screens and diagnostics show meaningful version info.

### Description

- Added a reusable `MainWindow::themedIcon(...)` helper and applied it to tray, toolbar, and menu actions so icons prefer the KDE/desktop icon theme with Qt fallbacks. 
- Expanded tray and main menus with KDE-typical actions: added `Configure Notifications` entry (in tray and File menu) that tries to launch `systemsettings5` or `kcmshell5`, and added a `Help` menu with an `About KGitHub Notify` dialog implemented in `showAboutDialog()`. 
- Wired project version into runtime by setting `project(... VERSION ...)` in `CMakeLists.txt`, emitting `KGHN_APP_VERSION` to the compile defines, and calling `QApplication::setApplicationVersion(...)` in `main.cpp`. 
- Minor API additions and includes: new slots `showAboutDialog()` and `openKdeNotificationSettings()` and declaration of `themedIcon(...)` in `src/MainWindow.h`, plus README update to document the KDE-first integration.

### Testing

- Ran `git diff --check` with no issues reported. 
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j4`, which failed in this environment because the Qt5 CMake package is not available (environment limitation), so a local build verification was not possible here. 
- No UI or network automated tests were added per repository guidance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7e4ba420832fad5c53a7377d7261)