### PR TITLE
Fix cppcheck knownConditionTrueFalse warning in NotificationRuleEngine.cpp

### DIFF
--- a/src/NotificationRuleEngine.cpp
+++ b/src/NotificationRuleEngine.cpp
@@ -66,7 +66,7 @@ bool NotificationRule::matches(const Notification& n) const {
         } else {
             isMatch = value.contains(actualFilter, Qt::CaseInsensitive);
             // exact match for type/reason if not using wildcard logic natively
-            if (!isWildcard && (actualFilter.compare(value, Qt::CaseInsensitive) == 0)) {
+            if (actualFilter.compare(value, Qt::CaseInsensitive) == 0) {
                 isMatch = true;
             }
         }


### PR DESCRIPTION
Fix cppcheck knownConditionTrueFalse warning in NotificationRuleEngine.cpp

Removed the redundant `!isWildcard` check in `NotificationRuleEngine::matchField` since it was already inside the `else` block of `if (isWildcard)`, making it always true. This resolves a cppcheck `[knownConditionTrueFalse]` warning.

---
*PR created automatically by Jules for task [16207557366996275240](https://jules.google.com/task/16207557366996275240) started by @arran4*