### PR TITLE
Fix clang-format issues

### DIFF
--- a/src/ActionWindow.cpp
+++ b/src/ActionWindow.cpp
@@ -6,7 +6,7 @@
 #include <QJsonObject>
 #include <QMessageBox>
 
-ActionWindow::ActionWindow(const Notification &n, GitHubClient *client, QWidget *parent)
+ActionWindow::ActionWindow(const Notification& n, GitHubClient* client, QWidget* parent)
     : KXmlGuiWindow(parent, Qt::Window),
       m_notification(n),
       m_client(client),
@@ -20,12 +20,12 @@ ActionWindow::ActionWindow(const Notification &n, GitHubClient *client, QWidget 
 }
 
 void ActionWindow::setupUi() {
-    QWidget *centralWidget = new QWidget(this);
+    QWidget* centralWidget = new QWidget(this);
     setObjectName("ActionWindow");
     setCentralWidget(centralWidget);
     setupGUI(Default, ":/kgithub-notifyui.rc");
 
-    QVBoxLayout *layout = new QVBoxLayout(centralWidget);
+    QVBoxLayout* layout = new QVBoxLayout(centralWidget);
 
     m_statusLabel = new QLabel(tr("<b>Status:</b> Loading..."));
     m_statusLabel->setWordWrap(true);
@@ -44,11 +44,11 @@ void ActionWindow::setupUi() {
 void ActionWindow::fetchRunDetails() {
     QUrl url(m_notification.url);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
-    QNetworkReply *reply = m_manager->get(request);
+    QNetworkReply* reply = m_manager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onRunDetailsReply(reply); });
 }
 
-void ActionWindow::onRunDetailsReply(QNetworkReply *reply) {
+void ActionWindow::onRunDetailsReply(QNetworkReply* reply) {
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -75,11 +75,11 @@ void ActionWindow::fetchJobs() {
 
     QUrl url(m_jobsUrl);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
-    QNetworkReply *reply = m_manager->get(request);
+    QNetworkReply* reply = m_manager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onJobsReply(reply); });
 }
 
-void ActionWindow::onJobsReply(QNetworkReply *reply) {
+void ActionWindow::onJobsReply(QNetworkReply* reply) {
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);

--- a/src/ActionWindow.h
+++ b/src/ActionWindow.h
@@ -16,22 +16,22 @@ class ActionWindow : public KXmlGuiWindow {
     Q_OBJECT
 
    public:
-    explicit ActionWindow(const Notification &n, GitHubClient *client, QWidget *parent = nullptr);
+    explicit ActionWindow(const Notification& n, GitHubClient* client, QWidget* parent = nullptr);
 
    private slots:
     void fetchRunDetails();
-    void onRunDetailsReply(QNetworkReply *reply);
+    void onRunDetailsReply(QNetworkReply* reply);
 
     void fetchJobs();
-    void onJobsReply(QNetworkReply *reply);
+    void onJobsReply(QNetworkReply* reply);
 
    private:
     Notification m_notification;
-    GitHubClient *m_client;
-    QNetworkAccessManager *m_manager;
+    GitHubClient* m_client;
+    QNetworkAccessManager* m_manager;
 
-    QLabel *m_statusLabel;
-    QTableWidget *m_jobsTable;
+    QLabel* m_statusLabel;
+    QTableWidget* m_jobsTable;
     QString m_jobsUrl;
 
     void setupUi();

--- a/src/DebugWindow.cpp
+++ b/src/DebugWindow.cpp
@@ -7,7 +7,7 @@
 #include <QScrollArea>
 #include <QVBoxLayout>
 
-DebugWindow::DebugWindow(GitHubClient *client, QWidget *parent) : QDialog(parent), m_client(client) {
+DebugWindow::DebugWindow(GitHubClient* client, QWidget* parent) : QDialog(parent), m_client(client) {
     setWindowTitle(tr("Debug GitHub API"));
     resize(700, 600);
 
@@ -20,13 +20,13 @@ DebugWindow::DebugWindow(GitHubClient *client, QWidget *parent) : QDialog(parent
     m_presets.append({"List Issues", "GET", "/repos/{owner}/{repo}/issues", {"owner", "repo"}});
     m_presets.append({"Rate Limit", "GET", "/rate_limit", {}});
 
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    QVBoxLayout* mainLayout = new QVBoxLayout(this);
 
     // API Selection
-    QHBoxLayout *topLayout = new QHBoxLayout();
+    QHBoxLayout* topLayout = new QHBoxLayout();
     topLayout->addWidget(new QLabel(tr("API Action:")));
     m_apiSelector = new QComboBox(this);
-    for (const auto &preset : m_presets) {
+    for (const auto& preset : m_presets) {
         m_apiSelector->addItem(preset.name);
     }
     // Use the Qt 5 connect syntax for overloaded signals if needed, or function pointer
@@ -79,7 +79,7 @@ DebugWindow::DebugWindow(GitHubClient *client, QWidget *parent) : QDialog(parent
 void DebugWindow::onApiSelected(int index) {
     if (index < 0 || index >= m_presets.size()) return;
 
-    const ApiPreset &preset = m_presets[index];
+    const ApiPreset& preset = m_presets[index];
 
     // Update Method
     int methodIndex = m_methodSelector->findText(preset.method);
@@ -91,7 +91,7 @@ void DebugWindow::onApiSelected(int index) {
     m_endpointInput->setText(preset.endpoint);
 
     // Clear existing params
-    QLayoutItem *child;
+    QLayoutItem* child;
     while ((child = m_paramsLayout->takeAt(0)) != nullptr) {
         if (child->widget()) {
             child->widget()->deleteLater();
@@ -100,8 +100,8 @@ void DebugWindow::onApiSelected(int index) {
     }
 
     // Generate new params
-    for (const QString &param : preset.params) {
-        QLineEdit *input = new QLineEdit(this);
+    for (const QString& param : preset.params) {
+        QLineEdit* input = new QLineEdit(this);
         // Connect changes to update endpoint
         connect(input, &QLineEdit::textChanged, this, &DebugWindow::onParamChanged);
         m_paramsLayout->addRow(param + ":", input);
@@ -112,7 +112,7 @@ void DebugWindow::onParamChanged() {
     int index = m_apiSelector->currentIndex();
     if (index < 0 || index >= m_presets.size()) return;
 
-    const ApiPreset &preset = m_presets[index];
+    const ApiPreset& preset = m_presets[index];
     QString endpoint = preset.endpoint;
 
     // Iterate through params layout
@@ -121,9 +121,9 @@ void DebugWindow::onParamChanged() {
         // itemAt(row, role)
         // QFormLayout rows are indexed 0..count
         // But adding rows might interleave? No, addRow appends.
-        QLayoutItem *item = m_paramsLayout->itemAt(i, QFormLayout::FieldRole);
+        QLayoutItem* item = m_paramsLayout->itemAt(i, QFormLayout::FieldRole);
         if (item && item->widget()) {
-            QLineEdit *input = qobject_cast<QLineEdit *>(item->widget());
+            QLineEdit* input = qobject_cast<QLineEdit*>(item->widget());
             if (input) {
                 QString value = input->text();
                 endpoint.replace("{" + param + "}", value);
@@ -145,7 +145,7 @@ void DebugWindow::sendRequest() {
     m_client->requestRaw(endpoint, method, body);
 }
 
-void DebugWindow::displayResponse(const QByteArray &data) {
+void DebugWindow::displayResponse(const QByteArray& data) {
     // Only update if we are visible
     // Check if JSON and format it?
     QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -156,4 +156,4 @@ void DebugWindow::displayResponse(const QByteArray &data) {
     }
 }
 
-void DebugWindow::setEndpoint(const QString &url) { m_endpointInput->setText(url); }
+void DebugWindow::setEndpoint(const QString& url) { m_endpointInput->setText(url); }

--- a/src/DebugWindow.h
+++ b/src/DebugWindow.h
@@ -23,27 +23,27 @@ struct ApiPreset {
 class DebugWindow : public QDialog {
     Q_OBJECT
    public:
-    explicit DebugWindow(GitHubClient *client, QWidget *parent = nullptr);
-    void setEndpoint(const QString &url);
+    explicit DebugWindow(GitHubClient* client, QWidget* parent = nullptr);
+    void setEndpoint(const QString& url);
 
    private slots:
     void sendRequest();
-    void displayResponse(const QByteArray &data);
+    void displayResponse(const QByteArray& data);
     void onApiSelected(int index);
     void onParamChanged();
 
    private:
-    GitHubClient *m_client;
+    GitHubClient* m_client;
 
-    QComboBox *m_apiSelector;
-    QComboBox *m_methodSelector;
-    QWidget *m_paramsContainer;
-    QFormLayout *m_paramsLayout;
+    QComboBox* m_apiSelector;
+    QComboBox* m_methodSelector;
+    QWidget* m_paramsContainer;
+    QFormLayout* m_paramsLayout;
 
-    QLineEdit *m_endpointInput;
-    QTextEdit *m_bodyInput;
-    QTextEdit *m_responseOutput;
-    QPushButton *m_sendButton;
+    QLineEdit* m_endpointInput;
+    QTextEdit* m_bodyInput;
+    QTextEdit* m_responseOutput;
+    QPushButton* m_sendButton;
 
     QList<ApiPreset> m_presets;
 };

--- a/src/GitHubClient.cpp
+++ b/src/GitHubClient.cpp
@@ -12,7 +12,7 @@
 #include <QUrl>
 #include <QUrlQuery>
 
-GitHubClient::GitHubClient(QObject *parent) : QObject(parent) {
+GitHubClient::GitHubClient(QObject* parent) : QObject(parent) {
     manager = new QNetworkAccessManager(this);
     connect(manager, &QNetworkAccessManager::finished, this, &GitHubClient::onReplyFinished);
     m_apiUrl = "https://api.github.com";
@@ -25,7 +25,7 @@ GitHubClient::GitHubClient(QObject *parent) : QObject(parent) {
     connect(m_requestTimeoutTimer, &QTimer::timeout, this, &GitHubClient::onRequestTimeout);
 }
 
-QString GitHubClient::apiToHtmlUrl(const QString &apiUrl, const QString &notificationId) {
+QString GitHubClient::apiToHtmlUrl(const QString& apiUrl, const QString& notificationId) {
     QString htmlUrl = apiUrl;
     htmlUrl.replace("api.github.com/repos", "github.com");
     htmlUrl.replace("/pulls/", "/pull/");
@@ -41,9 +41,9 @@ QString GitHubClient::apiToHtmlUrl(const QString &apiUrl, const QString &notific
     return htmlUrl;
 }
 
-void GitHubClient::setToken(const QString &token) { m_token.set(token); }
+void GitHubClient::setToken(const QString& token) { m_token.set(token); }
 
-void GitHubClient::setApiUrl(const QString &url) { m_apiUrl = url; }
+void GitHubClient::setApiUrl(const QString& url) { m_apiUrl = url; }
 
 void GitHubClient::setShowAll(bool all) { m_showAll = all; }
 
@@ -69,7 +69,7 @@ void GitHubClient::checkNotifications() {
         m_activeNotificationReply->abort();
     }
 
-    QNetworkReply *reply = manager->get(request);
+    QNetworkReply* reply = manager->get(request);
     reply->setProperty("type", "notifications");
     reply->setProperty("append", false);
     m_activeNotificationReply = reply;
@@ -89,7 +89,7 @@ void GitHubClient::loadMore() {
     QUrl url(m_nextPageUrl);
     QNetworkRequest request = createAuthenticatedRequest(url);
 
-    QNetworkReply *reply = manager->get(request);
+    QNetworkReply* reply = manager->get(request);
     reply->setProperty("type", "notifications");
     reply->setProperty("append", true);
     m_activeNotificationReply = reply;
@@ -106,11 +106,11 @@ void GitHubClient::verifyToken() {
     QUrl url(m_apiUrl + "/user");
     QNetworkRequest request = createAuthenticatedRequest(url);
 
-    QNetworkReply *reply = manager->get(request);
+    QNetworkReply* reply = manager->get(request);
     reply->setProperty("type", "verification");
 }
 
-void GitHubClient::markAsRead(const QString &id) {
+void GitHubClient::markAsRead(const QString& id) {
     if (m_token.isEmpty()) return;
 
     m_pendingPatchRequests++;
@@ -118,11 +118,11 @@ void GitHubClient::markAsRead(const QString &id) {
     QUrl url(m_apiUrl + "/notifications/threads/" + id);
     QNetworkRequest request = createAuthenticatedRequest(url);
 
-    QNetworkReply *reply = manager->sendCustomRequest(request, "PATCH");
+    QNetworkReply* reply = manager->sendCustomRequest(request, "PATCH");
     reply->setProperty("type", "patch");
 }
 
-void GitHubClient::markAsDone(const QString &id) {
+void GitHubClient::markAsDone(const QString& id) {
     if (m_token.isEmpty()) return;
 
     m_pendingPatchRequests++;
@@ -130,11 +130,11 @@ void GitHubClient::markAsDone(const QString &id) {
     QUrl url(m_apiUrl + "/notifications/threads/" + id);
     QNetworkRequest request = createAuthenticatedRequest(url);
 
-    QNetworkReply *reply = manager->deleteResource(request);
+    QNetworkReply* reply = manager->deleteResource(request);
     reply->setProperty("type", "delete");
 }
 
-void GitHubClient::markAsReadAndDone(const QString &id) {
+void GitHubClient::markAsReadAndDone(const QString& id) {
     if (m_token.isEmpty()) return;
 
     m_pendingPatchRequests++;
@@ -142,34 +142,34 @@ void GitHubClient::markAsReadAndDone(const QString &id) {
     QUrl url(m_apiUrl + "/notifications/threads/" + id);
     QNetworkRequest request = createAuthenticatedRequest(url);
 
-    QNetworkReply *reply = manager->sendCustomRequest(request, "PATCH");
+    QNetworkReply* reply = manager->sendCustomRequest(request, "PATCH");
     reply->setProperty("type", "read_and_done");
     reply->setProperty("notificationId", id);
 }
 
-void GitHubClient::fetchNotificationDetails(const QString &url, const QString &notificationId) {
+void GitHubClient::fetchNotificationDetails(const QString& url, const QString& notificationId) {
     if (m_token.isEmpty() || url.isEmpty()) return;
     QUrl qUrl(url);
     if (!qUrl.isValid()) return;
     QNetworkRequest request = createRequest(qUrl);
-    QNetworkReply *reply = manager->get(request);
+    QNetworkReply* reply = manager->get(request);
     reply->setProperty("type", "details");
     reply->setProperty("notificationId", notificationId);
 }
 
-void GitHubClient::fetchImage(const QString &imageUrl, const QString &notificationId) {
+void GitHubClient::fetchImage(const QString& imageUrl, const QString& notificationId) {
     QUrl qUrl(imageUrl);
     QNetworkRequest request(qUrl);
     // Images (avatars) are usually public, so no auth header needed.
     // Also, User-Agent is good practice.
     request.setRawHeader("User-Agent", "Kgithub-notify");
 
-    QNetworkReply *reply = manager->get(request);
+    QNetworkReply* reply = manager->get(request);
     reply->setProperty("type", "image");
     reply->setProperty("notificationId", notificationId);
 }
 
-void GitHubClient::requestRaw(const QString &endpoint, const QString &method, const QByteArray &body) {
+void GitHubClient::requestRaw(const QString& endpoint, const QString& method, const QByteArray& body) {
     if (m_token.isEmpty()) return;
     QString urlStr = endpoint.startsWith("http") ? endpoint : m_apiUrl + endpoint;
     QUrl url(urlStr);
@@ -179,7 +179,7 @@ void GitHubClient::requestRaw(const QString &endpoint, const QString &method, co
         request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     }
 
-    QNetworkReply *reply = nullptr;
+    QNetworkReply* reply = nullptr;
     QString m = method.toUpper();
 
     if (m == "GET") {
@@ -199,7 +199,7 @@ void GitHubClient::requestRaw(const QString &endpoint, const QString &method, co
     }
 }
 
-void GitHubClient::fetchUserRepos(const QString &pageUrl) {
+void GitHubClient::fetchUserRepos(const QString& pageUrl) {
     if (m_token.isEmpty()) return;
 
     QUrl url;
@@ -214,13 +214,13 @@ void GitHubClient::fetchUserRepos(const QString &pageUrl) {
     }
 
     QNetworkRequest request = createAuthenticatedRequest(url);
-    QNetworkReply *reply = manager->get(request);
+    QNetworkReply* reply = manager->get(request);
     reply->setProperty("type", "repos");
 }
 
-QNetworkRequest GitHubClient::createAuthenticatedRequest(const QUrl &url) const { return createRequest(url); }
+QNetworkRequest GitHubClient::createAuthenticatedRequest(const QUrl& url) const { return createRequest(url); }
 
-QNetworkRequest GitHubClient::createRequest(const QUrl &url) const {
+QNetworkRequest GitHubClient::createRequest(const QUrl& url) const {
     QNetworkRequest request(url);
 
     // Add Authorization header
@@ -233,12 +233,12 @@ QNetworkRequest GitHubClient::createRequest(const QUrl &url) const {
 
     // Explicitly zero out sensitive data
     if (!tokenBytes.isEmpty()) {
-        volatile char *p = tokenBytes.data();
+        volatile char* p = tokenBytes.data();
         size_t s = tokenBytes.size();
         while (s--) *p++ = 0;
     }
     if (!authHeader.isEmpty()) {
-        volatile char *p = authHeader.data();
+        volatile char* p = authHeader.data();
         size_t s = authHeader.size();
         while (s--) *p++ = 0;
     }
@@ -249,7 +249,7 @@ QNetworkRequest GitHubClient::createRequest(const QUrl &url) const {
     return request;
 }
 
-void GitHubClient::onReplyFinished(QNetworkReply *reply) {
+void GitHubClient::onReplyFinished(QNetworkReply* reply) {
     if (reply == m_activeNotificationReply) {
         m_requestTimeoutTimer->stop();
         m_activeNotificationReply = nullptr;
@@ -313,7 +313,7 @@ void GitHubClient::onReplyFinished(QNetworkReply *reply) {
     reply->deleteLater();
 }
 
-void GitHubClient::handleDetailsReply(QNetworkReply *reply) {
+void GitHubClient::handleDetailsReply(QNetworkReply* reply) {
     QString notificationId = reply->property("notificationId").toString();
     if (reply->error() != QNetworkReply::NoError) {
         qDebug() << "Error fetching details:" << reply->errorString();
@@ -344,7 +344,7 @@ void GitHubClient::handleDetailsReply(QNetworkReply *reply) {
     }
 }
 
-void GitHubClient::handleImageReply(QNetworkReply *reply) {
+void GitHubClient::handleImageReply(QNetworkReply* reply) {
     QString notificationId = reply->property("notificationId").toString();
     if (reply->error() != QNetworkReply::NoError) {
         qDebug() << "Error fetching image:" << reply->errorString();
@@ -358,7 +358,7 @@ void GitHubClient::handleImageReply(QNetworkReply *reply) {
     }
 }
 
-void GitHubClient::handleVerificationReply(QNetworkReply *reply) {
+void GitHubClient::handleVerificationReply(QNetworkReply* reply) {
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -376,7 +376,7 @@ void GitHubClient::handleVerificationReply(QNetworkReply *reply) {
     }
 }
 
-void GitHubClient::handleUserReposReply(QNetworkReply *reply) {
+void GitHubClient::handleUserReposReply(QNetworkReply* reply) {
     if (reply->error() != QNetworkReply::NoError) {
         if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
             emit authError("Invalid Token");
@@ -407,7 +407,7 @@ void GitHubClient::handleUserReposReply(QNetworkReply *reply) {
     emit userReposReceived(doc.array(), nextPageUrl);
 }
 
-void GitHubClient::handlePatchReply(QNetworkReply *reply) {
+void GitHubClient::handlePatchReply(QNetworkReply* reply) {
     m_pendingPatchRequests--;
     if (m_pendingPatchRequests < 0) {
         m_pendingPatchRequests = 0;
@@ -427,7 +427,7 @@ void GitHubClient::handlePatchReply(QNetworkReply *reply) {
     }
 }
 
-void GitHubClient::handleNotificationsReply(QNetworkReply *reply) {
+void GitHubClient::handleNotificationsReply(QNetworkReply* reply) {
     if (reply->error() != QNetworkReply::NoError) {
         if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
             emit authError("Invalid Token");
@@ -448,7 +448,7 @@ void GitHubClient::handleNotificationsReply(QNetworkReply *reply) {
     QJsonArray array = doc.array();
 
     QList<Notification> notifications;
-    for (const QJsonValue &value : array) {
+    for (const QJsonValue& value : array) {
         if (!value.isObject()) continue;
 
         QJsonObject obj = value.toObject();
@@ -497,17 +497,17 @@ void GitHubClient::onRequestTimeout() {
     }
 }
 
-void GitHubClient::verifyRepo(const QString &repoFullName) {
+void GitHubClient::verifyRepo(const QString& repoFullName) {
     if (m_token.isEmpty()) return;
 
     QUrl url(m_apiUrl + "/repos/" + repoFullName);
     QNetworkRequest request = createAuthenticatedRequest(url);
-    QNetworkReply *reply = manager->get(request);
+    QNetworkReply* reply = manager->get(request);
     reply->setProperty("type", "verifyRepo");
     reply->setProperty("repoFullName", repoFullName);
 }
 
-void GitHubClient::handleRepoVerifyReply(QNetworkReply *reply) {
+void GitHubClient::handleRepoVerifyReply(QNetworkReply* reply) {
     QString repoFullName = reply->property("repoFullName").toString();
     if (reply->error() == QNetworkReply::NoError) {
         emit repoVerified(repoFullName, true);
@@ -516,8 +516,8 @@ void GitHubClient::handleRepoVerifyReply(QNetworkReply *reply) {
     }
 }
 
-void GitHubClient::createIssue(const QString &repoFullName, const QString &title, const QString &body,
-                               const QString &assignee) {
+void GitHubClient::createIssue(const QString& repoFullName, const QString& title, const QString& body,
+                               const QString& assignee) {
     if (m_token.isEmpty()) return;
 
     QUrl url(m_apiUrl + "/repos/" + repoFullName + "/issues");
@@ -538,6 +538,6 @@ void GitHubClient::createIssue(const QString &repoFullName, const QString &title
     QJsonDocument doc(obj);
     QByteArray postData = doc.toJson(QJsonDocument::Compact);
 
-    QNetworkReply *reply = manager->post(request, postData);
+    QNetworkReply* reply = manager->post(request, postData);
     reply->setProperty("type", "createIssue");
 }

--- a/src/GitHubClient.h
+++ b/src/GitHubClient.h
@@ -19,64 +19,64 @@ class GitHubClient : public QObject {
     friend class TestGitHubClient;
 
    public:
-    explicit GitHubClient(QObject *parent = nullptr);
-    static QString apiToHtmlUrl(const QString &apiUrl, const QString &notificationId = "");
-    void setToken(const QString &token);
-    void setApiUrl(const QString &url);
+    explicit GitHubClient(QObject* parent = nullptr);
+    static QString apiToHtmlUrl(const QString& apiUrl, const QString& notificationId = "");
+    void setToken(const QString& token);
+    void setApiUrl(const QString& url);
     void setShowAll(bool all);
     void checkNotifications();
     void loadMore();
     void verifyToken();
-    void markAsRead(const QString &id);
-    void markAsDone(const QString &id);
-    void markAsReadAndDone(const QString &id);
-    void fetchNotificationDetails(const QString &url, const QString &notificationId);
-    void fetchImage(const QString &imageUrl, const QString &notificationId);
-    void requestRaw(const QString &endpoint, const QString &method = "GET", const QByteArray &body = QByteArray());
-    void fetchUserRepos(const QString &pageUrl = QString());
-    void verifyRepo(const QString &repoFullName);
-    void createIssue(const QString &repoFullName, const QString &title, const QString &body,
-                     const QString &assignee = "");
-    QNetworkRequest createAuthenticatedRequest(const QUrl &url) const;
+    void markAsRead(const QString& id);
+    void markAsDone(const QString& id);
+    void markAsReadAndDone(const QString& id);
+    void fetchNotificationDetails(const QString& url, const QString& notificationId);
+    void fetchImage(const QString& imageUrl, const QString& notificationId);
+    void requestRaw(const QString& endpoint, const QString& method = "GET", const QByteArray& body = QByteArray());
+    void fetchUserRepos(const QString& pageUrl = QString());
+    void verifyRepo(const QString& repoFullName);
+    void createIssue(const QString& repoFullName, const QString& title, const QString& body,
+                     const QString& assignee = "");
+    QNetworkRequest createAuthenticatedRequest(const QUrl& url) const;
 
    signals:
     void loadingStarted();
-    void notificationsReceived(const QList<Notification> &notifications, bool append, bool hasMore);
-    void detailsReceived(const QString &notificationId, const QString &authorName, const QString &avatarUrl,
-                         const QString &htmlUrl);
-    void detailsError(const QString &notificationId, const QString &error);
-    void imageReceived(const QString &notificationId, const QPixmap &avatar);
-    void rawDataReceived(const QByteArray &data);
-    void userReposReceived(const QJsonArray &repos, const QString &nextPageUrl);
-    void errorOccurred(const QString &error);
-    void authError(const QString &message);
-    void tokenVerified(bool valid, const QString &message);
-    void repoVerified(const QString &repoFullName, bool exists);
-    void issueCreated(const QByteArray &data);
+    void notificationsReceived(const QList<Notification>& notifications, bool append, bool hasMore);
+    void detailsReceived(const QString& notificationId, const QString& authorName, const QString& avatarUrl,
+                         const QString& htmlUrl);
+    void detailsError(const QString& notificationId, const QString& error);
+    void imageReceived(const QString& notificationId, const QPixmap& avatar);
+    void rawDataReceived(const QByteArray& data);
+    void userReposReceived(const QJsonArray& repos, const QString& nextPageUrl);
+    void errorOccurred(const QString& error);
+    void authError(const QString& message);
+    void tokenVerified(bool valid, const QString& message);
+    void repoVerified(const QString& repoFullName, bool exists);
+    void issueCreated(const QByteArray& data);
 
    private slots:
-    void onReplyFinished(QNetworkReply *reply);
+    void onReplyFinished(QNetworkReply* reply);
     void onRequestTimeout();
 
    private:
-    QNetworkAccessManager *manager;
+    QNetworkAccessManager* manager;
     SecureString m_token;
     QString m_apiUrl;
     bool m_showAll;
     int m_pendingPatchRequests;
     QString m_nextPageUrl;
     QPointer<QNetworkReply> m_activeNotificationReply;
-    QTimer *m_requestTimeoutTimer;
+    QTimer* m_requestTimeoutTimer;
 
-    QNetworkRequest createRequest(const QUrl &url) const;
+    QNetworkRequest createRequest(const QUrl& url) const;
 
-    void handleDetailsReply(QNetworkReply *reply);
-    void handleImageReply(QNetworkReply *reply);
-    void handleVerificationReply(QNetworkReply *reply);
-    void handleUserReposReply(QNetworkReply *reply);
-    void handleRepoVerifyReply(QNetworkReply *reply);
-    void handlePatchReply(QNetworkReply *reply);
-    void handleNotificationsReply(QNetworkReply *reply);
+    void handleDetailsReply(QNetworkReply* reply);
+    void handleImageReply(QNetworkReply* reply);
+    void handleVerificationReply(QNetworkReply* reply);
+    void handleUserReposReply(QNetworkReply* reply);
+    void handleRepoVerifyReply(QNetworkReply* reply);
+    void handlePatchReply(QNetworkReply* reply);
+    void handleNotificationsReply(QNetworkReply* reply);
 };
 
 #endif  // GITHUBCLIENT_H

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -57,7 +57,7 @@ static int calculateSafeInterval(int minutes) {
 // Constructor / Destructor
 // -----------------------------------------------------------------------------
 
-MainWindow::MainWindow(QWidget *parent)
+MainWindow::MainWindow(QWidget* parent)
     : KXmlGuiWindow(parent),
       debugWindow(nullptr),
       repoListWindow(nullptr),
@@ -94,7 +94,7 @@ MainWindow::~MainWindow() {
 // Public Methods
 // -----------------------------------------------------------------------------
 
-void MainWindow::setClient(GitHubClient *c) {
+void MainWindow::setClient(GitHubClient* c) {
     client = c;
     connect(client, &GitHubClient::loadingStarted, this, &MainWindow::onLoadingStarted);
     connect(client, &GitHubClient::notificationsReceived, this, &MainWindow::updateNotifications);
@@ -113,7 +113,7 @@ void MainWindow::setClient(GitHubClient *c) {
     connect(notificationListWidget, &NotificationListWidget::requestImage, client, &GitHubClient::fetchImage);
     connect(notificationListWidget, &NotificationListWidget::markAsRead, client, &GitHubClient::markAsRead);
     connect(notificationListWidget, &NotificationListWidget::requestDebugApi, this,
-            [this](const QString &url) { showDebugWindow(url); });
+            [this](const QString& url) { showDebugWindow(url); });
     connect(notificationListWidget, &NotificationListWidget::markAsDone, client, &GitHubClient::markAsDone);
     connect(notificationListWidget, &NotificationListWidget::loadMoreRequested, client, &GitHubClient::loadMore);
 
@@ -130,11 +130,11 @@ void MainWindow::setClient(GitHubClient *c) {
     }
 }
 
-void MainWindow::showTrayMessage(const QString &title, const QString &message) {
+void MainWindow::showTrayMessage(const QString& title, const QString& message) {
     trayIcon->showMessage(title, message, QSystemTrayIcon::Information, 3000);
 }
 
-void MainWindow::showDesktopFileWarning(const QString &desktopFileName, const QStringList &appPaths) {
+void MainWindow::showDesktopFileWarning(const QString& desktopFileName, const QStringList& appPaths) {
     desktopWarningMessage =
         tr("The desktop file <b>%1</b> was not found in standard application paths.<br><br>"
            "This may prevent the system tray icon and notifications from working correctly due to portal "
@@ -152,7 +152,7 @@ void MainWindow::showDesktopFileWarning(const QString &desktopFileName, const QS
 // Slots
 // -----------------------------------------------------------------------------
 
-void MainWindow::updateNotifications(const QList<Notification> &notifications, bool append, bool hasMore) {
+void MainWindow::updateNotifications(const QList<Notification>& notifications, bool append, bool hasMore) {
     m_lastCheckTime = QDateTime::currentDateTime();
     pendingAuthError = false;
     lastError.clear();
@@ -170,7 +170,7 @@ void MainWindow::updateNotifications(const QList<Notification> &notifications, b
     }
 }
 
-void MainWindow::onListCountsChanged(int total, int unread, int newCount, const QList<Notification> &newItems) {
+void MainWindow::onListCountsChanged(int total, int unread, int newCount, const QList<Notification>& newItems) {
     m_lastUnreadCount = unread;
     updateTrayIconState(unread, newCount, newItems);
 
@@ -204,13 +204,13 @@ void MainWindow::onListCountsChanged(int total, int unread, int newCount, const 
     repoFilterComboBox->blockSignals(wasBlocked);
 }
 
-void MainWindow::onListStatusMessage(const QString &message) {
+void MainWindow::onListStatusMessage(const QString& message) {
     if (countLabel) {
         countLabel->setText(message);
     }
 }
 
-void MainWindow::showError(const QString &error) {
+void MainWindow::showError(const QString& error) {
     if (error == lastError) return;
     lastError = error;
 
@@ -243,7 +243,7 @@ void MainWindow::showError(const QString &error) {
     updateTrayToolTip();
 }
 
-void MainWindow::onAuthError(const QString &message) {
+void MainWindow::onAuthError(const QString& message) {
     pendingAuthError = true;
 
     errorLabel->setText(tr("Authentication Error: %1\n\nPlease update your token in Settings.").arg(message));
@@ -449,7 +449,7 @@ void MainWindow::showAboutDialog() {
     aboutBox.exec();
 }
 
-void MainWindow::showDebugWindow(const QString &url) {
+void MainWindow::showDebugWindow(const QString& url) {
     if (!debugWindow) {
         debugWindow = new DebugWindow(client, this);
     }
@@ -494,7 +494,7 @@ void MainWindow::openKdeNotificationSettings() {
     }
 }
 
-void MainWindow::closeEvent(QCloseEvent *event) {
+void MainWindow::closeEvent(QCloseEvent* event) {
     if (trayIcon->isVisible()) {
         hide();
         event->ignore();
@@ -522,7 +522,7 @@ void MainWindow::updateTrayMenu() {
     if (!trayIconMenu) return;
     trayIconMenu->clear();
 
-    QAction *openAppAction =
+    QAction* openAppAction =
         new QAction(themedIcon({QStringLiteral("kgithub-notify")}), tr("Open Kgithub-notify"), trayIconMenu);
     QFont font = openAppAction->font();
     font.setBold(true);
@@ -537,15 +537,15 @@ void MainWindow::updateTrayMenu() {
         notificationListWidget ? notificationListWidget->getUnreadNotifications() : QList<Notification>();
 
     if (unreadCount > 0) {
-        QMenu *unreadMenu = new QMenu(tr("%1 Unread Notifications").arg(unreadCount), trayIconMenu);
+        QMenu* unreadMenu = new QMenu(tr("%1 Unread Notifications").arg(unreadCount), trayIconMenu);
         trayIconMenu->addMenu(unreadMenu);
 
         int limit = qMin(static_cast<int>(unreadNotifications.size()), SettingsDialog::getTrayUnreadLimit());
         for (int i = 0; i < limit; ++i) {
-            const Notification &n = unreadNotifications[i];
+            const Notification& n = unreadNotifications[i];
             QString label = QString("%1: %2").arg(n.repository, n.title);
 
-            QAction *itemAction = new QAction(label, unreadMenu);
+            QAction* itemAction = new QAction(label, unreadMenu);
             QString id = n.id;
             QString url = n.url;
 
@@ -561,7 +561,7 @@ void MainWindow::updateTrayMenu() {
 
         unreadMenu->addSeparator();
 
-        QAction *dismissAllAction = new QAction(tr("Dismiss All"), unreadMenu);
+        QAction* dismissAllAction = new QAction(tr("Dismiss All"), unreadMenu);
         connect(dismissAllAction, &QAction::triggered, this, [this]() {
             QMessageBox::StandardButton reply = QMessageBox::question(
                 this, tr("Dismiss All"), tr("Are you sure you want to dismiss all unread notifications?"),
@@ -572,25 +572,25 @@ void MainWindow::updateTrayMenu() {
         });
         unreadMenu->addAction(dismissAllAction);
     } else {
-        QAction *empty = new QAction(tr("No new notifications"), trayIconMenu);
+        QAction* empty = new QAction(tr("No new notifications"), trayIconMenu);
         empty->setEnabled(false);
         trayIconMenu->addAction(empty);
     }
 
     trayIconMenu->addSeparator();
 
-    QAction *trayRefreshAction =
+    QAction* trayRefreshAction =
         new QAction(themedIcon({QStringLiteral("view-refresh")}), tr("Force Refresh"), trayIconMenu);
     connect(trayRefreshAction, &QAction::triggered, this, &MainWindow::onRefreshClicked);
     trayIconMenu->addAction(trayRefreshAction);
 
-    QAction *newIssueTrayAction = new QAction(tr("New Issue..."), trayIconMenu);
+    QAction* newIssueTrayAction = new QAction(tr("New Issue..."), trayIconMenu);
     connect(newIssueTrayAction, &QAction::triggered, this, &MainWindow::showNewIssueDialog);
     trayIconMenu->addAction(newIssueTrayAction);
 
     trayIconMenu->addSeparator();
 
-    QAction *quitAction = new QAction(themedIcon({QStringLiteral("application-exit")}), tr("Quit"), trayIconMenu);
+    QAction* quitAction = new QAction(themedIcon({QStringLiteral("application-exit")}), tr("Quit"), trayIconMenu);
     connect(quitAction, &QAction::triggered, qApp, &QApplication::quit);
     trayIconMenu->addAction(quitAction);
 
@@ -619,7 +619,7 @@ void MainWindow::updateTrayToolTip() {
     if (!unreadNotifications.isEmpty()) {
         int limit = qMin(unreadNotifications.size(), 5);
         for (int i = 0; i < limit; ++i) {
-            const Notification &n = unreadNotifications[i];
+            const Notification& n = unreadNotifications[i];
             parts << QStringLiteral("- %1: %2").arg(n.repository, n.title);
         }
         if (m_lastUnreadCount > 5) {
@@ -641,7 +641,7 @@ void MainWindow::updateTrayToolTip() {
     trayIcon->setToolTip(parts.join(QStringLiteral("\n")));
 }
 
-void MainWindow::positionPopup(QWidget *popup) {
+void MainWindow::positionPopup(QWidget* popup) {
     if (!popup) return;
 
     QRect screenGeom = QGuiApplication::primaryScreen()->availableGeometry();
@@ -669,7 +669,7 @@ void MainWindow::positionPopup(QWidget *popup) {
 
 void MainWindow::createErrorPage() {
     errorPage = new QWidget(this);
-    QVBoxLayout *layout = new QVBoxLayout(errorPage);
+    QVBoxLayout* layout = new QVBoxLayout(errorPage);
     layout->setAlignment(Qt::AlignCenter);
 
     errorLabel = new QLabel(tr("Authentication Error"), errorPage);
@@ -685,7 +685,7 @@ void MainWindow::createErrorPage() {
 
 void MainWindow::createLoginPage() {
     loginPage = new QWidget(this);
-    QVBoxLayout *layout = new QVBoxLayout(loginPage);
+    QVBoxLayout* layout = new QVBoxLayout(loginPage);
     layout->setAlignment(Qt::AlignCenter);
 
     loginLabel = new QLabel(
@@ -703,7 +703,7 @@ void MainWindow::createLoginPage() {
 
 void MainWindow::createEmptyStatePage() {
     emptyStatePage = new QWidget(this);
-    QVBoxLayout *layout = new QVBoxLayout(emptyStatePage);
+    QVBoxLayout* layout = new QVBoxLayout(emptyStatePage);
     layout->setAlignment(Qt::AlignCenter);
 
     emptyStateLabel = new QLabel(tr("No new notifications"), emptyStatePage);
@@ -714,7 +714,7 @@ void MainWindow::createEmptyStatePage() {
 
 void MainWindow::createLoadingPage() {
     loadingPage = new QWidget(this);
-    QVBoxLayout *layout = new QVBoxLayout(loadingPage);
+    QVBoxLayout* layout = new QVBoxLayout(loadingPage);
     layout->setAlignment(Qt::AlignCenter);
 
     loadingLabel = new QLabel(tr("Loading..."), loadingPage);
@@ -758,7 +758,7 @@ void MainWindow::setupNotificationList() {
     notificationListWidget = new NotificationListWidget(this);
     connect(notificationListWidget, &NotificationListWidget::countsChanged, this, &MainWindow::onListCountsChanged);
     connect(notificationListWidget, &NotificationListWidget::statusMessage, this, &MainWindow::onListStatusMessage);
-    connect(notificationListWidget, &NotificationListWidget::linkActivated, this, [this](const QUrl &url) {
+    connect(notificationListWidget, &NotificationListWidget::linkActivated, this, [this](const QUrl& url) {
         // Do nothing specific, link already opened. Maybe update status?
     });
 
@@ -809,14 +809,14 @@ void MainWindow::setupToolbar() {
     searchLineEdit = new QLineEdit(this);
     searchLineEdit->setPlaceholderText(tr("Search..."));
     searchLineEdit->setFixedWidth(200);
-    connect(searchLineEdit, &QLineEdit::textChanged, this, [this](const QString &text) {
+    connect(searchLineEdit, &QLineEdit::textChanged, this, [this](const QString& text) {
         if (notificationListWidget) {
             notificationListWidget->setSearchFilter(text);
         }
     });
     toolbar->addWidget(searchLineEdit);
 
-    QComboBox *sortComboBox = new QComboBox(this);
+    QComboBox* sortComboBox = new QComboBox(this);
     sortComboBox->addItem(tr("Default (API Order)"));
     sortComboBox->addItem(tr("Updated (Newest)"));
     sortComboBox->addItem(tr("Updated (Oldest)"));
@@ -896,7 +896,7 @@ void MainWindow::setupMenus() {
     KStandardAction::deselect(this, &MainWindow::onSelectNoneClicked, actionCollection());
     KStandardAction::redisplay(this, &MainWindow::onRefreshClicked, actionCollection());
     KStandardAction::aboutApp(this, &MainWindow::showAboutDialog, actionCollection());
-    QAction *notificationRulesAction =
+    QAction* notificationRulesAction =
         new QAction(themedIcon({QStringLiteral("view-list-details")}), tr("Notification &Rules..."), this);
     connect(notificationRulesAction, &QAction::triggered, this, []() {
         RulesDialog dialog;
@@ -904,34 +904,34 @@ void MainWindow::setupMenus() {
     });
     actionCollection()->addAction(QStringLiteral("notification_rules"), notificationRulesAction);
 
-    QAction *notificationsSettingsAction = new QAction(themedIcon({QStringLiteral("preferences-desktop-notification")}),
+    QAction* notificationsSettingsAction = new QAction(themedIcon({QStringLiteral("preferences-desktop-notification")}),
                                                        tr("Configure &Notifications..."), this);
     connect(notificationsSettingsAction, &QAction::triggered, this, &MainWindow::openKdeNotificationSettings);
     actionCollection()->addAction(QStringLiteral("notifications_settings"), notificationsSettingsAction);
 
-    QAction *trendingAction = new QAction(tr("Trending Repos & Devs"), this);
+    QAction* trendingAction = new QAction(tr("Trending Repos & Devs"), this);
     connect(trendingAction, &QAction::triggered, this, &MainWindow::showTrendingWindow);
     actionCollection()->addAction(QStringLiteral("trending"), trendingAction);
 
-    QAction *debugAction = new QAction(tr("Debug GitHub API"), this);
+    QAction* debugAction = new QAction(tr("Debug GitHub API"), this);
     connect(debugAction, &QAction::triggered, this, [this]() { showDebugWindow(); });
     actionCollection()->addAction(QStringLiteral("debug"), debugAction);
 
-    QAction *newIssueAction = new QAction(tr("New Issue..."), this);
+    QAction* newIssueAction = new QAction(tr("New Issue..."), this);
     connect(newIssueAction, &QAction::triggered, this, &MainWindow::showNewIssueDialog);
     actionCollection()->addAction(QStringLiteral("new_issue"), newIssueAction);
 
-    QAction *repoListAction = new QAction(tr("Repositories List"), this);
+    QAction* repoListAction = new QAction(tr("Repositories List"), this);
     connect(repoListAction, &QAction::triggered, this, &MainWindow::showRepoListWindow);
     actionCollection()->addAction(QStringLiteral("repo_list"), repoListAction);
 
-    KActionMenu *issuesMenu = new KActionMenu(tr("Issues"), this);
+    KActionMenu* issuesMenu = new KActionMenu(tr("Issues"), this);
     actionCollection()->addAction(QStringLiteral("issues_menu"), issuesMenu);
 
-    KActionMenu *prsMenu = new KActionMenu(tr("Pull Requests"), this);
+    KActionMenu* prsMenu = new KActionMenu(tr("Pull Requests"), this);
     actionCollection()->addAction(QStringLiteral("prs_menu"), prsMenu);
 
-    KActionMenu *reposMenu = new KActionMenu(tr("Repositories"), this);
+    KActionMenu* reposMenu = new KActionMenu(tr("Repositories"), this);
     actionCollection()->addAction(QStringLiteral("repos_menu"), reposMenu);
 
     struct Variant {
@@ -959,16 +959,16 @@ void MainWindow::setupMenus() {
          "archived:true user:@me"},
         {tr("All (Unfiltered)"), "unfiltered", "involves:@me", "involves:@me", "user:@me"}};
 
-    auto createSubMenu = [&](KActionMenu *parentMenu, const QString &statusName, const QString &statusId,
-                             const QString &statusQuery, const QString &typeQuery, int endpointType) {
-        KActionMenu *statusMenu = parentMenu;
+    auto createSubMenu = [&](KActionMenu* parentMenu, const QString& statusName, const QString& statusId,
+                             const QString& statusQuery, const QString& typeQuery, int endpointType) {
+        KActionMenu* statusMenu = parentMenu;
         if (!statusName.isEmpty()) {
             statusMenu = new KActionMenu(statusName, this);
             actionCollection()->addAction(QStringLiteral("submenu_") + statusId, statusMenu);
             parentMenu->addAction(statusMenu);
         }
 
-        for (const auto &v : variants) {
+        for (const auto& v : variants) {
             QString vQuery;
             if (endpointType == 0)
                 vQuery = v.issueQuery;
@@ -980,7 +980,7 @@ void MainWindow::setupMenus() {
             if (vQuery.isEmpty()) continue;
 
             QString finalQuery = QString("%1 %2 %3").arg(typeQuery, statusQuery, vQuery).trimmed();
-            QAction *action = new QAction(v.name, this);
+            QAction* action = new QAction(v.name, this);
             connect(action, &QAction::triggered, this, [=]() { showWorkItems(v.name, endpointType, finalQuery); });
 
             QString actionName = QStringLiteral("action_") + statusId + QStringLiteral("_") + v.actionId;
@@ -1000,16 +1000,16 @@ void MainWindow::setupMenus() {
 
     createSubMenu(reposMenu, "", "repos", "", "", 2);
 
-    QAction *aboutQtAction = new QAction(tr("About &Qt"), this);
+    QAction* aboutQtAction = new QAction(tr("About &Qt"), this);
     connect(aboutQtAction, &QAction::triggered, qApp, &QApplication::aboutQt);
     actionCollection()->addAction(QStringLiteral("about_qt"), aboutQtAction);
 
     setupGUI(Default, ":/kgithub-notifyui.rc");
 }
-void MainWindow::showWorkItems(const QString &title, int endpointType, const QString &query) {
+void MainWindow::showWorkItems(const QString& title, int endpointType, const QString& query) {
     WorkItemWindow::EndpointType type =
         (endpointType == 0) ? WorkItemWindow::EndpointIssues : WorkItemWindow::EndpointRepositories;
-    WorkItemWindow *window = new WorkItemWindow(client, title, type, query, this);
+    WorkItemWindow* window = new WorkItemWindow(client, title, type, query, this);
     window->setAttribute(Qt::WA_DeleteOnClose);
     window->show();
 }
@@ -1053,9 +1053,9 @@ void MainWindow::loadToken() {
     tokenWatcher->setFuture(SettingsDialog::getTokenAsync());
 }
 
-QIcon MainWindow::themedIcon(const QStringList &names, const QString &fallbackResource,
+QIcon MainWindow::themedIcon(const QStringList& names, const QString& fallbackResource,
                              QStyle::StandardPixmap fallbackPixmap) const {
-    for (const QString &name : names) {
+    for (const QString& name : names) {
         QIcon icon = QIcon::fromTheme(name);
         if (!icon.isNull()) {
             return icon;
@@ -1072,8 +1072,8 @@ QIcon MainWindow::themedIcon(const QStringList &names, const QString &fallbackRe
     return QApplication::style()->standardIcon(fallbackPixmap);
 }
 
-void MainWindow::sendNotification(const Notification &n) {
-    KNotification *notification = new KNotification("NewNotification");
+void MainWindow::sendNotification(const Notification& n) {
+    KNotification* notification = new KNotification("NewNotification");
     notification->setComponentName(QStringLiteral("kgithub-notify"));
     notification->setTitle(n.repository);
     notification->setText(n.title);
@@ -1098,8 +1098,8 @@ void MainWindow::sendNotification(const Notification &n) {
     notification->sendEvent();
 }
 
-void MainWindow::sendSummaryNotification(int count, const QList<Notification> &notifications) {
-    KNotification *notification = new KNotification("NewNotification");
+void MainWindow::sendSummaryNotification(int count, const QList<Notification>& notifications) {
+    KNotification* notification = new KNotification("NewNotification");
     notification->setComponentName(QStringLiteral("kgithub-notify"));
     notification->setTitle(tr("%1 New Notifications").arg(count));
 
@@ -1128,7 +1128,7 @@ void MainWindow::sendSummaryNotification(int count, const QList<Notification> &n
 }
 
 void MainWindow::updateTrayIconState(int unreadCount, int newNotifications,
-                                     const QList<Notification> &newlyAddedNotifications) {
+                                     const QList<Notification>& newlyAddedNotifications) {
     if (unreadCount <= 0) {
         trayIcon->setIcon(themedIcon({QStringLiteral("kgithub-notify")}, QStringLiteral(":/assets/icon.png"),
                                      QStyle::SP_ComputerIcon));
@@ -1145,7 +1145,7 @@ void MainWindow::updateTrayIconState(int unreadCount, int newNotifications,
         QList<Notification> individualNotifications;
         QList<Notification> summarizedNotifications;
 
-        for (const Notification &n : newlyAddedNotifications) {
+        for (const Notification& n : newlyAddedNotifications) {
             if (!n.unread && !notifyRead) continue;
 
             QString action = NotificationRuleEngine::evaluate(n);
@@ -1166,7 +1166,7 @@ void MainWindow::updateTrayIconState(int unreadCount, int newNotifications,
 
         // Send summarize notifications if they exceed the threshold or if they explicitly asked to summarize
         bool hasAlwaysSummarize = false;
-        for (const Notification &n : summarizedNotifications) {
+        for (const Notification& n : summarizedNotifications) {
             if (NotificationRuleEngine::evaluate(n) == "AlwaysSummarize" ||
                 NotificationRuleEngine::evaluate(n) == "NeverIndividual") {
                 hasAlwaysSummarize = true;
@@ -1177,13 +1177,13 @@ void MainWindow::updateTrayIconState(int unreadCount, int newNotifications,
         if (summarizedNotifications.size() > threshold || (hasAlwaysSummarize && summarizedNotifications.size() > 0)) {
             sendSummaryNotification(summarizedNotifications.size(), summarizedNotifications);
         } else {
-            for (const Notification &n : summarizedNotifications) {
+            for (const Notification& n : summarizedNotifications) {
                 individualNotifications.append(n);
             }
         }
 
         int delayMs = 0;
-        for (const Notification &n : individualNotifications) {
+        for (const Notification& n : individualNotifications) {
             QTimer::singleShot(delayMs, this, [this, n]() { sendNotification(n); });
             delayMs += stepDelayMs;
         }
@@ -1212,7 +1212,7 @@ void MainWindow::updateSelectionComboBox() {
 }
 
 void MainWindow::showNewIssueDialog() {
-    NewIssueDialog *dialog = new NewIssueDialog(client, this);
+    NewIssueDialog* dialog = new NewIssueDialog(client, this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -36,16 +36,16 @@ class NewIssueDialog;
 class MainWindow : public KXmlGuiWindow {
     Q_OBJECT
    public:
-    explicit MainWindow(QWidget *parent = nullptr);
+    explicit MainWindow(QWidget* parent = nullptr);
     ~MainWindow();
-    void setClient(GitHubClient *client);
-    void showTrayMessage(const QString &title, const QString &message);
-    void showDesktopFileWarning(const QString &desktopFileName, const QStringList &appPaths);
+    void setClient(GitHubClient* client);
+    void showTrayMessage(const QString& title, const QString& message);
+    void showDesktopFileWarning(const QString& desktopFileName, const QStringList& appPaths);
 
    public slots:
-    void updateNotifications(const QList<Notification> &notifications, bool append, bool hasMore);
-    void showError(const QString &error);
-    void onAuthError(const QString &message);
+    void updateNotifications(const QList<Notification>& notifications, bool append, bool hasMore);
+    void showError(const QString& error);
+    void onAuthError(const QString& message);
 
    private slots:
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
@@ -67,25 +67,25 @@ class MainWindow : public KXmlGuiWindow {
     void onFilterChanged(int index);
     void showAboutDialog();
     void openKdeNotificationSettings();
-    void showDebugWindow(const QString &url = "");
+    void showDebugWindow(const QString& url = "");
     void showRepoListWindow();
     void showTrendingWindow();
     void showNewIssueDialog();
-    void showWorkItems(const QString &title, int endpointType, const QString &query);
+    void showWorkItems(const QString& title, int endpointType, const QString& query);
 
     // From ListWidget
-    void onListCountsChanged(int total, int unread, int newCount, const QList<Notification> &newItems);
-    void onListStatusMessage(const QString &message);
+    void onListCountsChanged(int total, int unread, int newCount, const QList<Notification>& newItems);
+    void onListStatusMessage(const QString& message);
 
    protected:
-    void closeEvent(QCloseEvent *event) override;
+    void closeEvent(QCloseEvent* event) override;
 
    private:
     // Helpers
     void createTrayIcon();
     void updateTrayMenu();
     void updateTrayToolTip();
-    void positionPopup(QWidget *popup);
+    void positionPopup(QWidget* popup);
     void createErrorPage();
     void createLoginPage();
     void createEmptyStatePage();
@@ -99,63 +99,63 @@ class MainWindow : public KXmlGuiWindow {
     void setupMenus();
     void setupStatusBar();
     void loadToken();
-    QIcon themedIcon(const QStringList &names, const QString &fallbackResource = QString(),
+    QIcon themedIcon(const QStringList& names, const QString& fallbackResource = QString(),
                      QStyle::StandardPixmap fallbackPixmap = QStyle::SP_FileIcon) const;
-    void sendNotification(const Notification &n);
-    void sendSummaryNotification(int count, const QList<Notification> &notifications);
+    void sendNotification(const Notification& n);
+    void sendSummaryNotification(int count, const QList<Notification>& notifications);
     void updateSelectionComboBox();
-    void updateTrayIconState(int unreadCount, int newNotifications, const QList<Notification> &newlyAddedNotifications);
+    void updateTrayIconState(int unreadCount, int newNotifications, const QList<Notification>& newlyAddedNotifications);
 
     // Member Variables
-    DebugWindow *debugWindow;
-    RepoListWindow *repoListWindow;
-    TrendingWindow *trendingWindow;
-    QSystemTrayIcon *trayIcon;
-    QMenu *trayIconMenu;
-    NotificationListWidget *notificationListWidget;
-    GitHubClient *client;
+    DebugWindow* debugWindow;
+    RepoListWindow* repoListWindow;
+    TrendingWindow* trendingWindow;
+    QSystemTrayIcon* trayIcon;
+    QMenu* trayIconMenu;
+    NotificationListWidget* notificationListWidget;
+    GitHubClient* client;
 
     bool pendingAuthError;
     QString lastError;
 
     // Toolbar
-    QToolBar *toolbar;
-    QAction *refreshAction;
-    QComboBox *filterComboBox;
-    QComboBox *repoFilterComboBox;
-    QLineEdit *searchLineEdit;
-    QAction *selectAllAction;
-    QAction *selectNoneAction;
-    QComboBox *selectionComboBox;
-    QAction *dismissSelectedAction;
-    QAction *openSelectedAction;
+    QToolBar* toolbar;
+    QAction* refreshAction;
+    QComboBox* filterComboBox;
+    QComboBox* repoFilterComboBox;
+    QLineEdit* searchLineEdit;
+    QAction* selectAllAction;
+    QAction* selectNoneAction;
+    QComboBox* selectionComboBox;
+    QAction* dismissSelectedAction;
+    QAction* openSelectedAction;
 
     // UI components
-    QStackedWidget *stackWidget;
-    QWidget *errorPage;
-    QLabel *errorLabel;
-    QPushButton *settingsButton;
-    QWidget *loginPage;
-    QLabel *loginLabel;
-    QPushButton *loginButton;
-    QWidget *emptyStatePage;
-    QLabel *emptyStateLabel;
-    QWidget *loadingPage;
-    QLabel *loadingLabel;
+    QStackedWidget* stackWidget;
+    QWidget* errorPage;
+    QLabel* errorLabel;
+    QPushButton* settingsButton;
+    QWidget* loginPage;
+    QLabel* loginLabel;
+    QPushButton* loginButton;
+    QWidget* emptyStatePage;
+    QLabel* emptyStateLabel;
+    QWidget* loadingPage;
+    QLabel* loadingLabel;
 
-    PopupNotification *authNotification;
+    PopupNotification* authNotification;
 
     // Status Bar
-    QStatusBar *statusBar;
-    QToolButton *desktopWarningButton;
+    QStatusBar* statusBar;
+    QToolButton* desktopWarningButton;
     QString desktopWarningMessage;
-    QLabel *countLabel;
-    QLabel *timerLabel;
-    QTimer *refreshTimer;
-    QTimer *countdownTimer;
-    QLabel *statusLabel;
+    QLabel* countLabel;
+    QLabel* timerLabel;
+    QTimer* refreshTimer;
+    QTimer* countdownTimer;
+    QLabel* statusLabel;
 
-    QFutureWatcher<QString> *tokenWatcher;
+    QFutureWatcher<QString>* tokenWatcher;
     QString m_loadedToken;
 
     QDateTime m_lastCheckTime;

--- a/src/NewIssueDialog.cpp
+++ b/src/NewIssueDialog.cpp
@@ -11,7 +11,7 @@
 #include <QUrl>
 #include <QVBoxLayout>
 
-NewIssueDialog::NewIssueDialog(GitHubClient *client, QWidget *parent)
+NewIssueDialog::NewIssueDialog(GitHubClient* client, QWidget* parent)
     : QDialog(parent), m_client(client), m_verifyTimer(new QTimer(this)), m_isFetchingRepos(false) {
     setupUI();
 
@@ -30,17 +30,17 @@ void NewIssueDialog::setupUI() {
     setWindowTitle(tr("New Issue"));
     resize(500, 450);
 
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    QVBoxLayout* mainLayout = new QVBoxLayout(this);
 
-    QLabel *instructionLabel = new QLabel(tr("Repository:"), this);
+    QLabel* instructionLabel = new QLabel(tr("Repository:"), this);
     mainLayout->addWidget(instructionLabel);
 
-    QHBoxLayout *repoLayout = new QHBoxLayout();
+    QHBoxLayout* repoLayout = new QHBoxLayout();
     m_repoComboBox = new QComboBox(this);
     m_repoComboBox->setEditable(true);
     m_repoComboBox->setInsertPolicy(QComboBox::NoInsert);
 
-    QCompleter *completer = m_repoComboBox->completer();
+    QCompleter* completer = m_repoComboBox->completer();
     if (completer) {
         completer->setCompletionMode(QCompleter::PopupCompletion);
         completer->setFilterMode(Qt::MatchContains);
@@ -56,19 +56,19 @@ void NewIssueDialog::setupUI() {
     repoLayout->addWidget(m_refreshButton);
     mainLayout->addLayout(repoLayout);
 
-    QLabel *titleLabel = new QLabel(tr("Title:"), this);
+    QLabel* titleLabel = new QLabel(tr("Title:"), this);
     mainLayout->addWidget(titleLabel);
 
     m_titleEdit = new QLineEdit(this);
     mainLayout->addWidget(m_titleEdit);
 
-    QLabel *assigneeLabel = new QLabel(tr("Assignee (username, optional):"), this);
+    QLabel* assigneeLabel = new QLabel(tr("Assignee (username, optional):"), this);
     mainLayout->addWidget(assigneeLabel);
 
     m_assigneeEdit = new QLineEdit(this);
     mainLayout->addWidget(m_assigneeEdit);
 
-    QLabel *bodyLabel = new QLabel(tr("Body:"), this);
+    QLabel* bodyLabel = new QLabel(tr("Body:"), this);
     mainLayout->addWidget(bodyLabel);
 
     m_bodyEdit = new QTextEdit(this);
@@ -80,10 +80,10 @@ void NewIssueDialog::setupUI() {
     m_statusLabel->setWordWrap(true);
     mainLayout->addWidget(m_statusLabel);
 
-    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    QHBoxLayout* buttonLayout = new QHBoxLayout();
     buttonLayout->addStretch();
 
-    QPushButton *cancelButton = new QPushButton(tr("Cancel"), this);
+    QPushButton* cancelButton = new QPushButton(tr("Cancel"), this);
     connect(cancelButton, &QPushButton::clicked, this, &QDialog::reject);
     buttonLayout->addWidget(cancelButton);
 
@@ -152,7 +152,7 @@ void NewIssueDialog::saveCache() {
     }
 }
 
-void NewIssueDialog::onRepoTextChanged(const QString &text) {
+void NewIssueDialog::onRepoTextChanged(const QString& text) {
     m_createButton->setEnabled(false);
 
     // Basic format check
@@ -187,7 +187,7 @@ void NewIssueDialog::verifyRepo() {
     m_client->verifyRepo(m_currentVerifyRepo);
 }
 
-void NewIssueDialog::onRepoVerified(const QString &repoFullName, bool exists) {
+void NewIssueDialog::onRepoVerified(const QString& repoFullName, bool exists) {
     if (repoFullName.compare(m_currentVerifyRepo, Qt::CaseInsensitive) != 0) return;
 
     if (exists) {
@@ -220,7 +220,7 @@ void NewIssueDialog::onCreateClicked() {
     m_client->createIssue(repoName, title, body, assignee);
 }
 
-void NewIssueDialog::onIssueCreated(const QByteArray &data) {
+void NewIssueDialog::onIssueCreated(const QByteArray& data) {
     QJsonDocument doc = QJsonDocument::fromJson(data);
     if (doc.isObject() && doc.object().contains("html_url")) {
         QString url = doc.object()["html_url"].toString();
@@ -254,7 +254,7 @@ void NewIssueDialog::onRefreshClicked() {
     m_client->fetchUserRepos();
 }
 
-void NewIssueDialog::onReposReceived(const QJsonArray &repos, const QString &nextPageUrl) {
+void NewIssueDialog::onReposReceived(const QJsonArray& repos, const QString& nextPageUrl) {
     if (!m_isFetchingRepos) return;
     for (int i = 0; i < repos.size(); ++i) {
         m_allRepos.append(repos[i]);
@@ -278,7 +278,7 @@ void NewIssueDialog::onReposReceived(const QJsonArray &repos, const QString &nex
     }
 }
 
-void NewIssueDialog::onErrorOccurred(const QString &error) {
+void NewIssueDialog::onErrorOccurred(const QString& error) {
     m_refreshButton->setEnabled(true);
     m_createButton->setEnabled(true);
     QString errMsg = tr("Error: %1").arg(error);
@@ -291,7 +291,7 @@ void NewIssueDialog::onErrorOccurred(const QString &error) {
     m_statusLabel->setStyleSheet("color: red;");
 }
 
-void NewIssueDialog::setInitialRepo(const QString &repoFullName) {
+void NewIssueDialog::setInitialRepo(const QString& repoFullName) {
     int index = m_repoComboBox->findText(repoFullName, Qt::MatchExactly);
     if (index >= 0) {
         m_repoComboBox->setCurrentIndex(index);

--- a/src/NewIssueDialog.h
+++ b/src/NewIssueDialog.h
@@ -16,33 +16,33 @@ class NewIssueDialog : public QDialog {
     Q_OBJECT
 
    public:
-    explicit NewIssueDialog(GitHubClient *client, QWidget *parent = nullptr);
-    void setInitialRepo(const QString &repoFullName);
+    explicit NewIssueDialog(GitHubClient* client, QWidget* parent = nullptr);
+    void setInitialRepo(const QString& repoFullName);
 
    private slots:
-    void onRepoTextChanged(const QString &text);
+    void onRepoTextChanged(const QString& text);
     void verifyRepo();
-    void onRepoVerified(const QString &repoFullName, bool exists);
+    void onRepoVerified(const QString& repoFullName, bool exists);
     void onCreateClicked();
     void onRefreshClicked();
-    void onReposReceived(const QJsonArray &repos, const QString &nextPageUrl);
-    void onIssueCreated(const QByteArray &data);
-    void onErrorOccurred(const QString &error);
+    void onReposReceived(const QJsonArray& repos, const QString& nextPageUrl);
+    void onIssueCreated(const QByteArray& data);
+    void onErrorOccurred(const QString& error);
 
    private:
     void setupUI();
     void loadCache();
     void saveCache();
 
-    GitHubClient *m_client;
-    QComboBox *m_repoComboBox;
-    QLineEdit *m_titleEdit;
-    QTextEdit *m_bodyEdit;
-    QLineEdit *m_assigneeEdit;
-    QPushButton *m_createButton;
-    QPushButton *m_refreshButton;
-    QLabel *m_statusLabel;
-    QTimer *m_verifyTimer;
+    GitHubClient* m_client;
+    QComboBox* m_repoComboBox;
+    QLineEdit* m_titleEdit;
+    QTextEdit* m_bodyEdit;
+    QLineEdit* m_assigneeEdit;
+    QPushButton* m_createButton;
+    QPushButton* m_refreshButton;
+    QLabel* m_statusLabel;
+    QTimer* m_verifyTimer;
 
     QJsonArray m_allRepos;
     QString m_currentVerifyRepo;

--- a/src/Notification.cpp
+++ b/src/Notification.cpp
@@ -16,7 +16,7 @@ QJsonObject Notification::toJson() const {
     return obj;
 }
 
-Notification Notification::fromJson(const QJsonObject &obj) {
+Notification Notification::fromJson(const QJsonObject& obj) {
     Notification n;
     n.id = obj["id"].toString();
     n.title = obj["title"].toString();

--- a/src/Notification.h
+++ b/src/Notification.h
@@ -18,7 +18,7 @@ struct Notification {
     QJsonObject rawJson;
 
     QJsonObject toJson() const;
-    static Notification fromJson(const QJsonObject &obj);
+    static Notification fromJson(const QJsonObject& obj);
 };
 
 #endif  // NOTIFICATION_H

--- a/src/NotificationItemWidget.cpp
+++ b/src/NotificationItemWidget.cpp
@@ -10,8 +10,8 @@
 #include <QPixmap>
 #include <QStyle>
 
-static QIcon getThemedIcon(const QStringList &names, QStyle *style, QStyle::StandardPixmap fallback) {
-    for (const QString &name : names) {
+static QIcon getThemedIcon(const QStringList& names, QStyle* style, QStyle::StandardPixmap fallback) {
+    for (const QString& name : names) {
         if (QIcon::hasThemeIcon(name)) {
             return QIcon::fromTheme(name);
         }
@@ -19,9 +19,9 @@ static QIcon getThemedIcon(const QStringList &names, QStyle *style, QStyle::Stan
     return style->standardIcon(fallback);
 }
 
-NotificationItemWidget::NotificationItemWidget(const Notification &n, QWidget *parent)
+NotificationItemWidget::NotificationItemWidget(const Notification& n, QWidget* parent)
     : QWidget(parent), m_isLoading(false) {
-    QHBoxLayout *mainLayout = new QHBoxLayout(this);
+    QHBoxLayout* mainLayout = new QHBoxLayout(this);
     mainLayout->setContentsMargins(5, 5, 5, 5);
 
     setMinimumHeight(60);
@@ -50,10 +50,10 @@ NotificationItemWidget::NotificationItemWidget(const Notification &n, QWidget *p
     avatarLabel->setPixmap(placeholder);
     mainLayout->addWidget(avatarLabel);
 
-    QVBoxLayout *contentLayout = new QVBoxLayout();
+    QVBoxLayout* contentLayout = new QVBoxLayout();
 
     // Title Layout (Title + Status Icons)
-    QHBoxLayout *titleLayout = new QHBoxLayout();
+    QHBoxLayout* titleLayout = new QHBoxLayout();
     titleLayout->setContentsMargins(0, 0, 0, 0);
 
     titleLabel = new QLabel(n.title, this);
@@ -69,7 +69,7 @@ NotificationItemWidget::NotificationItemWidget(const Notification &n, QWidget *p
     contentLayout->addLayout(titleLayout);
 
     // Repo, Author and Type
-    QHBoxLayout *repoTypeLayout = new QHBoxLayout();
+    QHBoxLayout* repoTypeLayout = new QHBoxLayout();
     repoLabel = new QLabel(QString("Repo: <b>%1</b>").arg(n.repository.toHtmlEscaped()), this);
     repoLabel->setTextFormat(Qt::RichText);
 
@@ -119,7 +119,7 @@ NotificationItemWidget::NotificationItemWidget(const Notification &n, QWidget *p
     mainLayout->addLayout(contentLayout);
 
     // Action Buttons
-    QVBoxLayout *actionLayout = new QVBoxLayout();
+    QVBoxLayout* actionLayout = new QVBoxLayout();
     actionLayout->setContentsMargins(0, 0, 0, 0);
     actionLayout->setAlignment(Qt::AlignTop);
 
@@ -149,18 +149,18 @@ NotificationItemWidget::NotificationItemWidget(const Notification &n, QWidget *p
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
 }
 
-void NotificationItemWidget::setAuthor(const QString &name, const QPixmap &avatar) {
+void NotificationItemWidget::setAuthor(const QString& name, const QPixmap& avatar) {
     authorLabel->setText("Author: " + name);
     if (!avatar.isNull()) {
         avatarLabel->setPixmap(avatar.scaled(40, 40, Qt::KeepAspectRatio, Qt::SmoothTransformation));
     }
 }
 
-void NotificationItemWidget::setHtmlUrl(const QString &url) {
+void NotificationItemWidget::setHtmlUrl(const QString& url) {
     urlLabel->setText(QString("<a href=\"%1\">Open on GitHub</a>").arg(url.toHtmlEscaped()));
 }
 
-void NotificationItemWidget::setError(const QString &error) {
+void NotificationItemWidget::setError(const QString& error) {
     errorLabel->setText(tr("Error: %1").arg(error));
     errorLabel->show();
 }
@@ -184,7 +184,7 @@ void NotificationItemWidget::setLoading(bool loading) {
     }
 }
 
-void NotificationItemWidget::updateNotification(const Notification &n) {
+void NotificationItemWidget::updateNotification(const Notification& n) {
     if (titleLabel->text() != n.title) {
         titleLabel->setText(n.title);
     }

--- a/src/NotificationItemWidget.h
+++ b/src/NotificationItemWidget.h
@@ -14,29 +14,29 @@
 class NotificationItemWidget : public QWidget {
     Q_OBJECT
    public:
-    explicit NotificationItemWidget(const Notification &notification, QWidget *parent = nullptr);
+    explicit NotificationItemWidget(const Notification& notification, QWidget* parent = nullptr);
 
-    QToolButton *doneButton;
-    QToolButton *openButton;
-    QLabel *avatarLabel;
-    QLabel *titleLabel;
-    QLabel *repoLabel;
-    QLabel *authorLabel;
-    QLabel *typeLabel;
-    QLabel *dateLabel;
-    QLabel *urlLabel;
-    QLabel *errorLabel;
-    QLabel *loadingLabel;
-    QLabel *unreadIndicator;
+    QToolButton* doneButton;
+    QToolButton* openButton;
+    QLabel* avatarLabel;
+    QLabel* titleLabel;
+    QLabel* repoLabel;
+    QLabel* authorLabel;
+    QLabel* typeLabel;
+    QLabel* dateLabel;
+    QLabel* urlLabel;
+    QLabel* errorLabel;
+    QLabel* loadingLabel;
+    QLabel* unreadIndicator;
 
     QString getTitle() const { return titleLabel->text(); }
-    void setAuthor(const QString &name, const QPixmap &avatar);
-    void setHtmlUrl(const QString &url);
-    void setError(const QString &error);
+    void setAuthor(const QString& name, const QPixmap& avatar);
+    void setHtmlUrl(const QString& url);
+    void setError(const QString& error);
     void setRead(bool read);
     void setLoading(bool loading);
     bool isLoading() const { return m_isLoading; }
-    void updateNotification(const Notification &n);
+    void updateNotification(const Notification& n);
 
    signals:
     void doneClicked();

--- a/src/NotificationListWidget.cpp
+++ b/src/NotificationListWidget.cpp
@@ -27,7 +27,7 @@
 #include "RulesDialog.h"
 #include "SettingsDialog.h"
 
-NotificationListWidget::NotificationListWidget(QWidget *parent)
+NotificationListWidget::NotificationListWidget(QWidget* parent)
     : QWidget(parent),
       loadMoreItem(nullptr),
       m_filterMode(0),
@@ -38,7 +38,7 @@ NotificationListWidget::NotificationListWidget(QWidget *parent)
       m_client(nullptr) {
     loadKnownNotifications();
 
-    QVBoxLayout *layout = new QVBoxLayout(this);
+    QVBoxLayout* layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
 
     listWidget = new QListWidget(this);
@@ -74,10 +74,10 @@ NotificationListWidget::NotificationListWidget(QWidget *parent)
 
     markAsReadAction = new QAction(tr("Mark as Read"), this);
     connect(markAsReadAction, &QAction::triggered, this, [this]() {
-        QListWidgetItem *item = listWidget->currentItem();
+        QListWidgetItem* item = listWidget->currentItem();
         if (!item) return;
 
-        NotificationItemWidget *widget = qobject_cast<NotificationItemWidget *>(listWidget->itemWidget(item));
+        NotificationItemWidget* widget = qobject_cast<NotificationItemWidget*>(listWidget->itemWidget(item));
         if (widget && widget->isLoading()) return;
         if (widget) widget->setLoading(true);
 
@@ -113,7 +113,7 @@ NotificationListWidget::NotificationListWidget(QWidget *parent)
 
     viewRawAction = new QAction(tr("View Raw JSON"), this);
     connect(viewRawAction, &QAction::triggered, this, [this]() {
-        QListWidgetItem *item = listWidget->currentItem();
+        QListWidgetItem* item = listWidget->currentItem();
         if (!item) return;
 
         QJsonObject json = item->data(Qt::UserRole + 4).toJsonObject();
@@ -126,12 +126,12 @@ NotificationListWidget::NotificationListWidget(QWidget *parent)
         QJsonDocument doc(combined);
         QString rawJson = QString::fromUtf8(doc.toJson(QJsonDocument::Indented));
 
-        QDialog *dialog = new QDialog(this);
+        QDialog* dialog = new QDialog(this);
         dialog->setWindowTitle(tr("Raw JSON"));
         dialog->resize(600, 400);
 
-        QVBoxLayout *layout = new QVBoxLayout(dialog);
-        QTextEdit *textEdit = new QTextEdit(dialog);
+        QVBoxLayout* layout = new QVBoxLayout(dialog);
+        QTextEdit* textEdit = new QTextEdit(dialog);
         textEdit->setReadOnly(true);
         textEdit->setPlainText(rawJson);
         layout->addWidget(textEdit);
@@ -142,16 +142,16 @@ NotificationListWidget::NotificationListWidget(QWidget *parent)
     contextMenu->addAction(viewRawAction);
     contextMenu->addSeparator();
 
-    QAction *muteRepoAction = new QAction(tr("Mute Repository"), this);
+    QAction* muteRepoAction = new QAction(tr("Mute Repository"), this);
     connect(muteRepoAction, &QAction::triggered, this, [this]() {
-        QListWidgetItem *item = listWidget->currentItem();
+        QListWidgetItem* item = listWidget->currentItem();
         if (!item) return;
         QString currentId = item->data(Qt::UserRole + 1).toString();
         if (currentId.isEmpty()) return;
 
         Notification n;
         bool found = false;
-        for (const Notification &notif : m_allNotifications) {
+        for (const Notification& notif : m_allNotifications) {
             if (notif.id == currentId) {
                 n = notif;
                 found = true;
@@ -168,16 +168,16 @@ NotificationListWidget::NotificationListWidget(QWidget *parent)
                                  tr("Muted notifications for repository:\n%1").arg(n.repository));
     });
 
-    QAction *openRulesAction = new QAction(tr("Manage Notification Rules..."), this);
+    QAction* openRulesAction = new QAction(tr("Manage Notification Rules..."), this);
     connect(openRulesAction, &QAction::triggered, this, [this]() {
-        QListWidgetItem *item = listWidget->currentItem();
+        QListWidgetItem* item = listWidget->currentItem();
         if (!item) return;
         QString currentId = item->data(Qt::UserRole + 1).toString();
         if (currentId.isEmpty()) return;
 
         Notification n;
         bool found = false;
-        for (const Notification &notif : m_allNotifications) {
+        for (const Notification& notif : m_allNotifications) {
             if (notif.id == currentId) {
                 n = notif;
                 found = true;
@@ -194,7 +194,7 @@ NotificationListWidget::NotificationListWidget(QWidget *parent)
     contextMenu->addAction(openRulesAction);
 }
 
-void NotificationListWidget::setNotifications(const QList<Notification> &notifications, bool append, bool hasMore) {
+void NotificationListWidget::setNotifications(const QList<Notification>& notifications, bool append, bool hasMore) {
     if (!append) {
         m_allNotifications = notifications;
         m_pendingNewNotifications = 0;
@@ -204,7 +204,7 @@ void NotificationListWidget::setNotifications(const QList<Notification> &notific
     }
     m_hasMore = hasMore;
 
-    for (const Notification &n : notifications) {
+    for (const Notification& n : notifications) {
         if (!knownNotificationIds.contains(n.id)) {
             m_pendingNewNotifications++;
             knownNotificationIds.insert(n.id);
@@ -217,7 +217,7 @@ void NotificationListWidget::setNotifications(const QList<Notification> &notific
 
     // Emit progressively without triggering popups (newCount=0, empty list)
     int totalUnread = 0;
-    for (const auto &n : m_allNotifications) {
+    for (const auto& n : m_allNotifications) {
         if (n.unread) totalUnread++;
     }
     emit countsChanged(m_allNotifications.count(), totalUnread, 0, QList<Notification>());
@@ -225,7 +225,7 @@ void NotificationListWidget::setNotifications(const QList<Notification> &notific
     updateList();
 }
 
-void NotificationListWidget::resizeEvent(QResizeEvent *event) {
+void NotificationListWidget::resizeEvent(QResizeEvent* event) {
     QWidget::resizeEvent(event);
     handleLoadMoreStrategy();
 }
@@ -243,13 +243,13 @@ void NotificationListWidget::setSortMode(int mode) {
     updateList();
 }
 
-void NotificationListWidget::setRepoFilter(const QString &repo) {
+void NotificationListWidget::setRepoFilter(const QString& repo) {
     if (m_repoFilter == repo) return;
     m_repoFilter = repo;
     applyClientFilters();
 }
 
-void NotificationListWidget::setSearchFilter(const QString &text) {
+void NotificationListWidget::setSearchFilter(const QString& text) {
     if (m_searchFilter == text) return;
     m_searchFilter = text;
     applyClientFilters();
@@ -265,15 +265,15 @@ void NotificationListWidget::selectTop(int n) {
     int limit = qMin(n, count);
 
     for (int i = 0; i < limit; ++i) {
-        QListWidgetItem *item = listWidget->item(i);
+        QListWidgetItem* item = listWidget->item(i);
         if (item) item->setSelected(true);
     }
 }
 
 void NotificationListWidget::dismissSelected() {
-    QList<QListWidgetItem *> items = listWidget->selectedItems();
+    QList<QListWidgetItem*> items = listWidget->selectedItems();
     for (auto item : items) {
-        NotificationItemWidget *widget = qobject_cast<NotificationItemWidget *>(listWidget->itemWidget(item));
+        NotificationItemWidget* widget = qobject_cast<NotificationItemWidget*>(listWidget->itemWidget(item));
         if (widget && !widget->isLoading()) {
             widget->setLoading(true);
 
@@ -297,7 +297,7 @@ void NotificationListWidget::dismissSelected() {
 }
 
 void NotificationListWidget::openSelected() {
-    QList<QListWidgetItem *> items = listWidget->selectedItems();
+    QList<QListWidgetItem*> items = listWidget->selectedItems();
     for (auto item : items) {
         openUrlForItem(item);
     }
@@ -306,7 +306,7 @@ void NotificationListWidget::openSelected() {
 bool NotificationListWidget::willLoadMore() const {
     if (!loadMoreItem) return false;
 
-    QPushButton *btn = qobject_cast<QPushButton *>(listWidget->itemWidget(loadMoreItem));
+    QPushButton* btn = qobject_cast<QPushButton*>(listWidget->itemWidget(loadMoreItem));
     if (!btn || !btn->isEnabled()) return false;
 
     SettingsDialog::GetDataOption option = SettingsDialog::getGetDataOption();
@@ -340,7 +340,7 @@ bool NotificationListWidget::willLoadMore() const {
 void NotificationListWidget::handleLoadMoreStrategy() {
     bool currentlyLoading = false;
     if (loadMoreItem) {
-        QPushButton *btn = qobject_cast<QPushButton *>(listWidget->itemWidget(loadMoreItem));
+        QPushButton* btn = qobject_cast<QPushButton*>(listWidget->itemWidget(loadMoreItem));
         if (btn && !btn->isEnabled()) {
             currentlyLoading = true;
         }
@@ -350,7 +350,7 @@ void NotificationListWidget::handleLoadMoreStrategy() {
         triggerLoadMore();
     } else if (!currentlyLoading && m_countsDirty) {
         int totalUnread = 0;
-        for (const auto &n : m_allNotifications) {
+        for (const auto& n : m_allNotifications) {
             if (n.unread) totalUnread++;
         }
         emit countsChanged(m_allNotifications.count(), totalUnread, m_pendingNewNotifications,
@@ -361,9 +361,9 @@ void NotificationListWidget::handleLoadMoreStrategy() {
     }
 }
 
-void NotificationListWidget::focusNotification(const QString &id) {
+void NotificationListWidget::focusNotification(const QString& id) {
     for (int i = 0; i < listWidget->count(); ++i) {
-        QListWidgetItem *item = listWidget->item(i);
+        QListWidgetItem* item = listWidget->item(i);
         if (item->data(Qt::UserRole + 1).toString() == id) {
             listWidget->scrollToItem(item);
             listWidget->setCurrentItem(item);
@@ -378,7 +378,7 @@ QStringList NotificationListWidget::getAvailableRepos() const {
     // Iterate over visible items or all items?
     // Usually repo filter is based on currently loaded items
     for (int i = 0; i < listWidget->count(); ++i) {
-        QListWidgetItem *item = listWidget->item(i);
+        QListWidgetItem* item = listWidget->item(i);
         if (item == loadMoreItem) continue;
         QString repo = item->data(Qt::UserRole + 3).toString();
         if (!repo.isEmpty()) {
@@ -392,15 +392,15 @@ QStringList NotificationListWidget::getAvailableRepos() const {
 
 int NotificationListWidget::count() const { return listWidget->count(); }
 
-void NotificationListWidget::updateDetails(const QString &id, const QString &author, const QString &avatarUrl,
-                                           const QString &htmlUrl) {
-    NotificationDetails &details = detailsCache[id];
+void NotificationListWidget::updateDetails(const QString& id, const QString& author, const QString& avatarUrl,
+                                           const QString& htmlUrl) {
+    NotificationDetails& details = detailsCache[id];
     details.author = author;
     details.avatarUrl = avatarUrl;
     details.htmlUrl = htmlUrl;
     details.hasDetails = true;
 
-    NotificationItemWidget *widget = findNotificationWidget(id);
+    NotificationItemWidget* widget = findNotificationWidget(id);
     if (widget) {
         widget->setAuthor(author, details.avatar);
         widget->setHtmlUrl(htmlUrl);
@@ -411,28 +411,28 @@ void NotificationListWidget::updateDetails(const QString &id, const QString &aut
     }
 }
 
-void NotificationListWidget::updateImage(const QString &id, const QPixmap &pixmap) {
-    NotificationDetails &details = detailsCache[id];
+void NotificationListWidget::updateImage(const QString& id, const QPixmap& pixmap) {
+    NotificationDetails& details = detailsCache[id];
     details.avatar = pixmap;
     details.hasImage = true;
 
-    NotificationItemWidget *widget = findNotificationWidget(id);
+    NotificationItemWidget* widget = findNotificationWidget(id);
     if (widget) {
         widget->setAuthor(details.author, pixmap);
     }
 }
 
-void NotificationListWidget::updateError(const QString &id, const QString &error) {
-    NotificationItemWidget *widget = findNotificationWidget(id);
+void NotificationListWidget::updateError(const QString& id, const QString& error) {
+    NotificationItemWidget* widget = findNotificationWidget(id);
     if (widget) {
         widget->setError(error);
     }
 }
 
-void NotificationListWidget::onListContextMenu(const QPoint &pos) {
-    QListWidgetItem *item = listWidget->itemAt(pos);
+void NotificationListWidget::onListContextMenu(const QPoint& pos) {
+    QListWidgetItem* item = listWidget->itemAt(pos);
     if (item) {
-        NotificationItemWidget *widget = qobject_cast<NotificationItemWidget *>(listWidget->itemWidget(item));
+        NotificationItemWidget* widget = qobject_cast<NotificationItemWidget*>(listWidget->itemWidget(item));
         if (widget && widget->isLoading()) return;
 
         listWidget->setCurrentItem(item);
@@ -446,12 +446,12 @@ void NotificationListWidget::onListContextMenu(const QPoint &pos) {
     }
 }
 
-void NotificationListWidget::onItemActivated(QListWidgetItem *item) { openWindowForItem(item); }
+void NotificationListWidget::onItemActivated(QListWidgetItem* item) { openWindowForItem(item); }
 
 void NotificationListWidget::triggerLoadMore() {
     if (!loadMoreItem) return;
 
-    QPushButton *btn = qobject_cast<QPushButton *>(listWidget->itemWidget(loadMoreItem));
+    QPushButton* btn = qobject_cast<QPushButton*>(listWidget->itemWidget(loadMoreItem));
     if (btn && btn->isEnabled()) {
         btn->setEnabled(false);
         btn->setText(tr("Loading..."));
@@ -461,12 +461,12 @@ void NotificationListWidget::triggerLoadMore() {
 
 void NotificationListWidget::onLoadMoreClicked() { triggerLoadMore(); }
 
-void NotificationListWidget::insertNotificationItem(int row, const Notification &n) {
-    QListWidgetItem *item = new QListWidgetItem();
-    NotificationItemWidget *widget = new NotificationItemWidget(n);
+void NotificationListWidget::insertNotificationItem(int row, const Notification& n) {
+    QListWidgetItem* item = new QListWidgetItem();
+    NotificationItemWidget* widget = new NotificationItemWidget(n);
 
     if (detailsCache.contains(n.id)) {
-        const NotificationDetails &details = detailsCache[n.id];
+        const NotificationDetails& details = detailsCache[n.id];
         if (details.hasDetails) {
             widget->setAuthor(details.author, details.avatar);
             widget->setHtmlUrl(details.htmlUrl);
@@ -509,7 +509,7 @@ void NotificationListWidget::updateList() {
 
     // Prepare Target List
     QList<Notification> targetNotifications;
-    for (const Notification &n : m_allNotifications) {
+    for (const Notification& n : m_allNotifications) {
         bool show = false;
 
         QDateTime updated = QDateTime::fromString(n.updatedAt, Qt::ISODate);
@@ -552,7 +552,7 @@ void NotificationListWidget::updateList() {
     // Sort the list
     if (m_sortMode != SortDefault) {
         std::sort(targetNotifications.begin(), targetNotifications.end(),
-                  [this](const Notification &a, const Notification &b) {
+                  [this](const Notification& a, const Notification& b) {
                       switch (m_sortMode) {
                           case SortUpdatedDesc:
                               return a.updatedAt > b.updatedAt;
@@ -607,8 +607,8 @@ void NotificationListWidget::updateList() {
     // Sync Loop
     int i = 0;
     while (i < targetNotifications.size()) {
-        const Notification &n = targetNotifications[i];
-        QListWidgetItem *currentItem = listWidget->item(i);
+        const Notification& n = targetNotifications[i];
+        QListWidgetItem* currentItem = listWidget->item(i);
 
         // Check if current item matches target
         QString currentId = currentItem ? currentItem->data(Qt::UserRole + 1).toString() : QString();
@@ -622,8 +622,7 @@ void NotificationListWidget::updateList() {
 
         if (currentItem && currentId == n.id) {
             // Match: Update existing
-            NotificationItemWidget *widget =
-                qobject_cast<NotificationItemWidget *>(listWidget->itemWidget(currentItem));
+            NotificationItemWidget* widget = qobject_cast<NotificationItemWidget*>(listWidget->itemWidget(currentItem));
             if (widget) {
                 widget->updateNotification(n);
             }
@@ -636,7 +635,7 @@ void NotificationListWidget::updateList() {
             // Check if n.id exists later in the list
             int foundIndex = -1;
             for (int k = i + 1; k < listWidget->count(); ++k) {
-                QListWidgetItem *searchItem = listWidget->item(k);
+                QListWidgetItem* searchItem = listWidget->item(k);
                 if (searchItem == loadMoreItem) continue;
                 if (searchItem->data(Qt::UserRole + 1).toString() == n.id) {
                     foundIndex = k;
@@ -647,11 +646,11 @@ void NotificationListWidget::updateList() {
             if (foundIndex != -1) {
                 // Found later: Move it to current position 'i'
                 // Safely remove old item and widget
-                QWidget *widget = listWidget->itemWidget(listWidget->item(foundIndex));
+                QWidget* widget = listWidget->itemWidget(listWidget->item(foundIndex));
                 if (widget) {
                     widget->deleteLater();
                 }
-                QListWidgetItem *movedItem = listWidget->takeItem(foundIndex);
+                QListWidgetItem* movedItem = listWidget->takeItem(foundIndex);
                 delete movedItem;
 
                 insertNotificationItem(i, n);
@@ -666,12 +665,12 @@ void NotificationListWidget::updateList() {
     // Cleanup: Remove remaining items starting from i (excluding loadMoreItem if we want to keep it logic clean)
     // We iterate backwards to avoid index shifting issues
     for (int k = listWidget->count() - 1; k >= i; --k) {
-        QListWidgetItem *item = listWidget->item(k);
+        QListWidgetItem* item = listWidget->item(k);
         if (item == loadMoreItem) {
             // Handle loadMoreItem logic below, don't delete here unless we reset it
             continue;
         }
-        QWidget *w = listWidget->itemWidget(item);
+        QWidget* w = listWidget->itemWidget(item);
         if (w) w->deleteLater();
         delete listWidget->takeItem(k);
     }
@@ -681,7 +680,7 @@ void NotificationListWidget::updateList() {
     if (m_hasMore) {
         if (!loadMoreItem) {
             loadMoreItem = new QListWidgetItem();
-            QPushButton *loadMoreBtn = new QPushButton(tr("Load More"));
+            QPushButton* loadMoreBtn = new QPushButton(tr("Load More"));
             connect(loadMoreBtn, &QPushButton::clicked, this, &NotificationListWidget::onLoadMoreClicked);
 
             loadMoreItem->setSizeHint(loadMoreBtn->sizeHint());
@@ -693,13 +692,13 @@ void NotificationListWidget::updateList() {
             // Ensure it is at the very end
             int r = listWidget->row(loadMoreItem);
             if (r != listWidget->count() - 1) {
-                QWidget *w = listWidget->itemWidget(loadMoreItem);
+                QWidget* w = listWidget->itemWidget(loadMoreItem);
                 if (w) w->deleteLater();
                 listWidget->takeItem(r);
                 delete loadMoreItem;  // Delete old pointer
 
                 loadMoreItem = new QListWidgetItem();
-                QPushButton *loadMoreBtn = new QPushButton(tr("Load More"));
+                QPushButton* loadMoreBtn = new QPushButton(tr("Load More"));
                 connect(loadMoreBtn, &QPushButton::clicked, this, &NotificationListWidget::onLoadMoreClicked);
 
                 loadMoreItem->setSizeHint(loadMoreBtn->sizeHint());
@@ -708,7 +707,7 @@ void NotificationListWidget::updateList() {
                 listWidget->addItem(loadMoreItem);
                 listWidget->setItemWidget(loadMoreItem, loadMoreBtn);
             } else {
-                QPushButton *btn = qobject_cast<QPushButton *>(listWidget->itemWidget(loadMoreItem));
+                QPushButton* btn = qobject_cast<QPushButton*>(listWidget->itemWidget(loadMoreItem));
                 if (btn) {
                     btn->setEnabled(true);
                     btn->setText(tr("Load More"));
@@ -719,7 +718,7 @@ void NotificationListWidget::updateList() {
         if (loadMoreItem) {
             int r = listWidget->row(loadMoreItem);
             if (r >= 0) {
-                QWidget *w = listWidget->itemWidget(loadMoreItem);
+                QWidget* w = listWidget->itemWidget(loadMoreItem);
                 if (w) w->deleteLater();
                 delete listWidget->takeItem(r);
             }
@@ -742,7 +741,7 @@ void NotificationListWidget::applyClientFilters() {
     int visibleCount = 0;
 
     for (int i = 0; i < listWidget->count(); ++i) {
-        QListWidgetItem *item = listWidget->item(i);
+        QListWidgetItem* item = listWidget->item(i);
         if (item == loadMoreItem) continue;
 
         bool matchRepo = true;
@@ -769,21 +768,21 @@ void NotificationListWidget::applyClientFilters() {
     emit statusMessage(tr("Items: %1").arg(visibleCount));
 }
 
-NotificationItemWidget *NotificationListWidget::findNotificationWidget(const QString &id) {
+NotificationItemWidget* NotificationListWidget::findNotificationWidget(const QString& id) {
     for (int i = 0; i < listWidget->count(); ++i) {
-        QListWidgetItem *item = listWidget->item(i);
+        QListWidgetItem* item = listWidget->item(i);
         if (item->data(Qt::UserRole + 1).toString() == id) {
-            return qobject_cast<NotificationItemWidget *>(listWidget->itemWidget(item));
+            return qobject_cast<NotificationItemWidget*>(listWidget->itemWidget(item));
         }
     }
     return nullptr;
 }
 
 void NotificationListWidget::dismissCurrentItem() {
-    QListWidgetItem *item = listWidget->currentItem();
+    QListWidgetItem* item = listWidget->currentItem();
     if (!item) return;
 
-    NotificationItemWidget *widget = qobject_cast<NotificationItemWidget *>(listWidget->itemWidget(item));
+    NotificationItemWidget* widget = qobject_cast<NotificationItemWidget*>(listWidget->itemWidget(item));
     if (widget && widget->isLoading()) return;
     if (widget) widget->setLoading(true);
 
@@ -805,25 +804,25 @@ void NotificationListWidget::dismissCurrentItem() {
 }
 
 void NotificationListWidget::openUrlCurrentItem() {
-    QListWidgetItem *item = listWidget->currentItem();
+    QListWidgetItem* item = listWidget->currentItem();
     if (item) {
         openUrlForItem(item);
     }
 }
 
 void NotificationListWidget::openWindowCurrentItem() {
-    QListWidgetItem *item = listWidget->currentItem();
+    QListWidgetItem* item = listWidget->currentItem();
     if (item) {
         openWindowForItem(item);
     }
 }
 
-void NotificationListWidget::markAsReadAndRemoveItem(QListWidgetItem *item) {
+void NotificationListWidget::markAsReadAndRemoveItem(QListWidgetItem* item) {
     QString id = item->data(Qt::UserRole + 1).toString();
 
     emit markAsRead(id);
 
-    NotificationItemWidget *widget = qobject_cast<NotificationItemWidget *>(listWidget->itemWidget(item));
+    NotificationItemWidget* widget = qobject_cast<NotificationItemWidget*>(listWidget->itemWidget(item));
     if (widget) {
         widget->setRead(true);
     }
@@ -843,10 +842,10 @@ void NotificationListWidget::markAsReadAndRemoveItem(QListWidgetItem *item) {
     }
 }
 
-void NotificationListWidget::openUrlForItem(QListWidgetItem *item) {
+void NotificationListWidget::openUrlForItem(QListWidgetItem* item) {
     if (!item) return;
 
-    NotificationItemWidget *widget = qobject_cast<NotificationItemWidget *>(listWidget->itemWidget(item));
+    NotificationItemWidget* widget = qobject_cast<NotificationItemWidget*>(listWidget->itemWidget(item));
     if (widget && widget->isLoading()) return;
 
     QString apiUrl = item->data(Qt::UserRole).toString();
@@ -859,26 +858,26 @@ void NotificationListWidget::openUrlForItem(QListWidgetItem *item) {
     markAsReadAndRemoveItem(item);
 }
 
-void NotificationListWidget::openWindowForItem(QListWidgetItem *item) {
+void NotificationListWidget::openWindowForItem(QListWidgetItem* item) {
     if (!item) return;
 
-    NotificationItemWidget *widget = qobject_cast<NotificationItemWidget *>(listWidget->itemWidget(item));
+    NotificationItemWidget* widget = qobject_cast<NotificationItemWidget*>(listWidget->itemWidget(item));
     if (widget && widget->isLoading()) return;
 
     QJsonObject json = item->data(Qt::UserRole + 4).toJsonObject();
     Notification n = Notification::fromJson(json);
 
-    NotificationWindow *win = new NotificationWindow(n, m_client, this);
+    NotificationWindow* win = new NotificationWindow(n, m_client, this);
     win->setAttribute(Qt::WA_DeleteOnClose);
     connect(win, &NotificationWindow::debugApiRequested, this,
-            [this](const QString &url) { emit requestDebugApi(url); });
+            [this](const QString& url) { emit requestDebugApi(url); });
 
     connect(win, &NotificationWindow::actionRequested, this,
-            [this](const QString &actionName, const QString &id, const QString &url) {
+            [this](const QString& actionName, const QString& id, const QString& url) {
                 // Find item by ID
-                QListWidgetItem *targetItem = nullptr;
+                QListWidgetItem* targetItem = nullptr;
                 for (int i = 0; i < listWidget->count(); ++i) {
-                    QListWidgetItem *it = listWidget->item(i);
+                    QListWidgetItem* it = listWidget->item(i);
                     if (it->data(Qt::UserRole + 1).toString() == id) {
                         targetItem = it;
                         break;
@@ -908,7 +907,7 @@ void NotificationListWidget::openWindowForItem(QListWidgetItem *item) {
 }
 
 void NotificationListWidget::copyLinkCurrentItem() {
-    QListWidgetItem *item = listWidget->currentItem();
+    QListWidgetItem* item = listWidget->currentItem();
     if (item) {
         QString apiUrl = item->data(Qt::UserRole).toString();
         QString htmlUrl = GitHubClient::apiToHtmlUrl(apiUrl);
@@ -918,7 +917,7 @@ void NotificationListWidget::copyLinkCurrentItem() {
 
 QList<Notification> NotificationListWidget::getUnreadNotifications(int limit) const {
     QList<Notification> unread;
-    for (const auto &n : m_allNotifications) {
+    for (const auto& n : m_allNotifications) {
         if (n.unread) {
             unread.append(n);
             if (unread.count() >= limit) break;
@@ -930,7 +929,7 @@ QList<Notification> NotificationListWidget::getUnreadNotifications(int limit) co
 void NotificationListWidget::resetLoadMoreState() {
     if (!loadMoreItem) return;
 
-    QPushButton *btn = qobject_cast<QPushButton *>(listWidget->itemWidget(loadMoreItem));
+    QPushButton* btn = qobject_cast<QPushButton*>(listWidget->itemWidget(loadMoreItem));
     if (btn) {
         btn->setEnabled(true);
         btn->setText(tr("Retry Load More"));
@@ -944,7 +943,7 @@ void NotificationListWidget::loadKnownNotifications() {
 
         if (dir.exists()) {
             QStringList files = dir.entryList(QDir::Files);
-            for (const QString &file : files) {
+            for (const QString& file : files) {
                 knownNotificationIds.insert(file);
             }
         }
@@ -953,7 +952,7 @@ void NotificationListWidget::loadKnownNotifications() {
     }
 }
 
-void NotificationListWidget::addKnownNotification(const QString &id) {
+void NotificationListWidget::addKnownNotification(const QString& id) {
     if (SettingsDialog::getNotifyOnce() && !id.isEmpty()) {
         QString path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/known_notifications";
         QDir dir(path);
@@ -971,7 +970,7 @@ void NotificationListWidget::addKnownNotification(const QString &id) {
     }
 }
 
-void NotificationListWidget::removeKnownNotification(const QString &id) {
+void NotificationListWidget::removeKnownNotification(const QString& id) {
     if (SettingsDialog::getNotifyOnce() && !id.isEmpty()) {
         QString path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/known_notifications";
         QFile file(path + "/" + id);

--- a/src/NotificationListWidget.h
+++ b/src/NotificationListWidget.h
@@ -19,14 +19,14 @@ class NotificationItemWidget;
 class NotificationListWidget : public QWidget {
     Q_OBJECT
    public:
-    explicit NotificationListWidget(QWidget *parent = nullptr);
+    explicit NotificationListWidget(QWidget* parent = nullptr);
 
-    void setClient(GitHubClient *client) { m_client = client; }
-    void setNotifications(const QList<Notification> &notifications, bool append, bool hasMore);
+    void setClient(GitHubClient* client) { m_client = client; }
+    void setNotifications(const QList<Notification>& notifications, bool append, bool hasMore);
     void setFilterMode(int mode);  // 0: Inbox, 1: Unread, 2: Read
     void setSortMode(int mode);
-    void setRepoFilter(const QString &repo);
-    void setSearchFilter(const QString &text);
+    void setRepoFilter(const QString& repo);
+    void setSearchFilter(const QString& text);
 
     enum SortMode {
         SortDefault = 0,
@@ -47,7 +47,7 @@ class NotificationListWidget : public QWidget {
     void selectTop(int n);
     void dismissSelected();
     void openSelected();
-    void focusNotification(const QString &id);
+    void focusNotification(const QString& id);
 
     // Getters for filters
     QStringList getAvailableRepos() const;
@@ -55,30 +55,30 @@ class NotificationListWidget : public QWidget {
     QList<Notification> getUnreadNotifications(int limit = 5) const;
 
    protected:
-    void resizeEvent(QResizeEvent *event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
    public slots:
-    void updateDetails(const QString &id, const QString &author, const QString &avatarUrl, const QString &htmlUrl);
-    void updateImage(const QString &id, const QPixmap &pixmap);
-    void updateError(const QString &id, const QString &error);
+    void updateDetails(const QString& id, const QString& author, const QString& avatarUrl, const QString& htmlUrl);
+    void updateImage(const QString& id, const QPixmap& pixmap);
+    void updateError(const QString& id, const QString& error);
     void resetLoadMoreState();
 
    signals:
-    void countsChanged(int total, int unread, int newCount, const QList<Notification> &newItems);
-    void statusMessage(const QString &message);
-    void linkActivated(const QUrl &url);
+    void countsChanged(int total, int unread, int newCount, const QList<Notification>& newItems);
+    void statusMessage(const QString& message);
+    void linkActivated(const QUrl& url);
     void refreshRequested();
-    void markAsRead(const QString &id);
-    void markAsDone(const QString &id);
+    void markAsRead(const QString& id);
+    void markAsDone(const QString& id);
     void loadMoreRequested();
-    void notificationActivated(const QString &id);
-    void requestDetails(const QString &url, const QString &id);
-    void requestImage(const QString &url, const QString &id);
-    void requestDebugApi(const QString &url);
+    void notificationActivated(const QString& id);
+    void requestDetails(const QString& url, const QString& id);
+    void requestImage(const QString& url, const QString& id);
+    void requestDebugApi(const QString& url);
 
    private slots:
-    void onListContextMenu(const QPoint &pos);
-    void onItemActivated(QListWidgetItem *item);
+    void onListContextMenu(const QPoint& pos);
+    void onItemActivated(QListWidgetItem* item);
     void onLoadMoreClicked();
     void handleLoadMoreStrategy();
     bool willLoadMore() const;
@@ -95,26 +95,26 @@ class NotificationListWidget : public QWidget {
         bool hasImage = false;
     };
 
-    void insertNotificationItem(int row, const Notification &n);
+    void insertNotificationItem(int row, const Notification& n);
     void updateList();
     void applyClientFilters();
-    NotificationItemWidget *findNotificationWidget(const QString &id);
+    NotificationItemWidget* findNotificationWidget(const QString& id);
     void dismissCurrentItem();
     void openUrlCurrentItem();
     void openWindowCurrentItem();
-    void openUrlForItem(QListWidgetItem *item);
-    void openWindowForItem(QListWidgetItem *item);
+    void openUrlForItem(QListWidgetItem* item);
+    void openWindowForItem(QListWidgetItem* item);
     void copyLinkCurrentItem();
-    void markAsReadAndRemoveItem(QListWidgetItem *item);
+    void markAsReadAndRemoveItem(QListWidgetItem* item);
 
-    QListWidget *listWidget;
+    QListWidget* listWidget;
     QList<Notification> m_allNotifications;
     QMap<QString, NotificationDetails> detailsCache;
     QSet<QString> knownNotificationIds;
     void loadKnownNotifications();
-    void addKnownNotification(const QString &id);
-    void removeKnownNotification(const QString &id);
-    QListWidgetItem *loadMoreItem;
+    void addKnownNotification(const QString& id);
+    void removeKnownNotification(const QString& id);
+    QListWidgetItem* loadMoreItem;
 
     // Filters
     int m_filterMode;
@@ -127,15 +127,15 @@ class NotificationListWidget : public QWidget {
     bool m_countsDirty;
 
     // Context Menu
-    GitHubClient *m_client;
+    GitHubClient* m_client;
 
-    QMenu *contextMenu;
-    QAction *openWindowAction;
-    QAction *openUrlAction;
-    QAction *copyLinkAction;
-    QAction *markAsReadAction;
-    QAction *markAsDoneAction;
-    QAction *viewRawAction;
+    QMenu* contextMenu;
+    QAction* openWindowAction;
+    QAction* openUrlAction;
+    QAction* copyLinkAction;
+    QAction* markAsReadAction;
+    QAction* markAsDoneAction;
+    QAction* viewRawAction;
 };
 
 #endif  // NOTIFICATIONLISTWIDGET_H

--- a/src/NotificationWindow.cpp
+++ b/src/NotificationWindow.cpp
@@ -19,40 +19,40 @@
 #include "PullRequestWindow.h"
 #include "RulesDialog.h"
 
-NotificationWindow::NotificationWindow(const Notification &n, GitHubClient *client, QWidget *parent)
+NotificationWindow::NotificationWindow(const Notification& n, GitHubClient* client, QWidget* parent)
     : KXmlGuiWindow(parent, Qt::Window), m_notification(n), m_client(client) {
     setWindowTitle(tr("Notification Details - %1").arg(n.repository));
     resize(500, 400);
 
     // Menu Bar
-    QMenu *fileMenu = menuBar()->addMenu(tr("&File"));
-    QAction *closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
+    QMenu* fileMenu = menuBar()->addMenu(tr("&File"));
+    QAction* closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
     closeAction->setShortcut(QKeySequence::Close);
     connect(closeAction, &QAction::triggered, this, &NotificationWindow::close);
     fileMenu->addAction(closeAction);
 
-    QMenu *editMenu = menuBar()->addMenu(tr("&Edit"));
+    QMenu* editMenu = menuBar()->addMenu(tr("&Edit"));
 
-    QAction *copyLinkAction = new QAction(QIcon::fromTheme("edit-copy"), tr("Copy Link"), this);
+    QAction* copyLinkAction = new QAction(QIcon::fromTheme("edit-copy"), tr("Copy Link"), this);
     copyLinkAction->setShortcut(QKeySequence::Copy);
     connect(copyLinkAction, &QAction::triggered, this, &NotificationWindow::onCopyLink);
     editMenu->addAction(copyLinkAction);
 
-    QMenu *actionsMenu = menuBar()->addMenu(tr("&Actions"));
+    QMenu* actionsMenu = menuBar()->addMenu(tr("&Actions"));
 
-    QAction *openUrlAction = new QAction(QIcon::fromTheme("internet-web-browser"), tr("Open URL"), this);
+    QAction* openUrlAction = new QAction(QIcon::fromTheme("internet-web-browser"), tr("Open URL"), this);
     connect(openUrlAction, &QAction::triggered, this, &NotificationWindow::onOpenUrl);
     actionsMenu->addAction(openUrlAction);
 
-    QAction *markAsReadAction = new QAction(QIcon::fromTheme("mail-mark-read"), tr("Mark as Read"), this);
+    QAction* markAsReadAction = new QAction(QIcon::fromTheme("mail-mark-read"), tr("Mark as Read"), this);
     connect(markAsReadAction, &QAction::triggered, this, &NotificationWindow::onMarkAsRead);
     actionsMenu->addAction(markAsReadAction);
 
-    QAction *markAsDoneAction = new QAction(QIcon::fromTheme("task-complete"), tr("Mark as Done"), this);
+    QAction* markAsDoneAction = new QAction(QIcon::fromTheme("task-complete"), tr("Mark as Done"), this);
     connect(markAsDoneAction, &QAction::triggered, this, &NotificationWindow::onMarkAsDone);
     actionsMenu->addAction(markAsDoneAction);
     actionsMenu->addSeparator();
-    QAction *muteRepoAction = new QAction(QIcon::fromTheme("notifications-disabled"), tr("Mute Repository"), this);
+    QAction* muteRepoAction = new QAction(QIcon::fromTheme("notifications-disabled"), tr("Mute Repository"), this);
     connect(muteRepoAction, &QAction::triggered, this, [this]() {
         NotificationRule rule;
         rule.repoFilter = m_notification.repository;
@@ -63,7 +63,7 @@ NotificationWindow::NotificationWindow(const Notification &n, GitHubClient *clie
     });
     actionsMenu->addAction(muteRepoAction);
 
-    QAction *openRulesAction =
+    QAction* openRulesAction =
         new QAction(QIcon::fromTheme("view-list-details"), tr("Manage Notification Rules..."), this);
     connect(openRulesAction, &QAction::triggered, this, [this]() {
         RulesDialog dialog(this, m_notification.repository, m_notification.repository);
@@ -73,12 +73,12 @@ NotificationWindow::NotificationWindow(const Notification &n, GitHubClient *clie
 
     actionsMenu->addSeparator();
 
-    QAction *viewRawAction = new QAction(QIcon::fromTheme("text-x-generic"), tr("View Raw JSON"), this);
+    QAction* viewRawAction = new QAction(QIcon::fromTheme("text-x-generic"), tr("View Raw JSON"), this);
     connect(viewRawAction, &QAction::triggered, this, &NotificationWindow::onViewRawJson);
     actionsMenu->addAction(viewRawAction);
 
-    QAction *viewPullRequestAction = nullptr;
-    QAction *viewActionJobAction = nullptr;
+    QAction* viewPullRequestAction = nullptr;
+    QAction* viewActionJobAction = nullptr;
 
     if (m_notification.type == "PullRequest") {
         viewPullRequestAction = new QAction(QIcon::fromTheme("vcs-merge-request"), tr("View Pull Request"), this);
@@ -91,7 +91,7 @@ NotificationWindow::NotificationWindow(const Notification &n, GitHubClient *clie
     }
 
     // Tool Bar
-    QToolBar *toolBar = addToolBar(tr("Actions"));
+    QToolBar* toolBar = addToolBar(tr("Actions"));
     toolBar->setObjectName("NotificationActionsToolBar");
     toolBar->addAction(openUrlAction);
     toolBar->addAction(copyLinkAction);
@@ -111,38 +111,38 @@ NotificationWindow::NotificationWindow(const Notification &n, GitHubClient *clie
     }
 
     // Central Widget
-    QWidget *centralWidget = new QWidget(this);
-    QVBoxLayout *layout = new QVBoxLayout(centralWidget);
+    QWidget* centralWidget = new QWidget(this);
+    QVBoxLayout* layout = new QVBoxLayout(centralWidget);
 
     {
-        QLabel *lbl = new QLabel(tr("<b>ID:</b> %1").arg(n.id.toHtmlEscaped()));
+        QLabel* lbl = new QLabel(tr("<b>ID:</b> %1").arg(n.id.toHtmlEscaped()));
         lbl->setTextInteractionFlags(Qt::TextBrowserInteraction);
         layout->addWidget(lbl);
     }
     {
-        QLabel *lbl = new QLabel(tr("<b>Title:</b> %1").arg(n.title.toHtmlEscaped()));
+        QLabel* lbl = new QLabel(tr("<b>Title:</b> %1").arg(n.title.toHtmlEscaped()));
         lbl->setTextInteractionFlags(Qt::TextBrowserInteraction);
         layout->addWidget(lbl);
     }
     {
-        QLabel *lbl = new QLabel(tr("<b>Repository:</b> %1").arg(n.repository.toHtmlEscaped()));
+        QLabel* lbl = new QLabel(tr("<b>Repository:</b> %1").arg(n.repository.toHtmlEscaped()));
         lbl->setTextInteractionFlags(Qt::TextBrowserInteraction);
         layout->addWidget(lbl);
     }
     {
-        QLabel *lbl = new QLabel(tr("<b>Type:</b> %1").arg(n.type.toHtmlEscaped()));
+        QLabel* lbl = new QLabel(tr("<b>Type:</b> %1").arg(n.type.toHtmlEscaped()));
         lbl->setTextInteractionFlags(Qt::TextBrowserInteraction);
         layout->addWidget(lbl);
     }
     {
-        QLabel *lbl = new QLabel(tr("<b>Updated At:</b> %1").arg(n.updatedAt.toHtmlEscaped()));
+        QLabel* lbl = new QLabel(tr("<b>Updated At:</b> %1").arg(n.updatedAt.toHtmlEscaped()));
         lbl->setTextInteractionFlags(Qt::TextBrowserInteraction);
         layout->addWidget(lbl);
     }
 
     if (!n.lastReadAt.isEmpty()) {
         {
-            QLabel *lbl = new QLabel(tr("<b>Last Read At:</b> %1").arg(n.lastReadAt.toHtmlEscaped()));
+            QLabel* lbl = new QLabel(tr("<b>Last Read At:</b> %1").arg(n.lastReadAt.toHtmlEscaped()));
             lbl->setTextInteractionFlags(Qt::TextBrowserInteraction);
             layout->addWidget(lbl);
         }
@@ -151,13 +151,13 @@ NotificationWindow::NotificationWindow(const Notification &n, GitHubClient *clie
     QString apiUrl = n.url;
     QString htmlUrl = GitHubClient::apiToHtmlUrl(apiUrl, n.id);
 
-    QLabel *urlLabel = new QLabel(tr("<b>API URL:</b> <a href=\"%1\">%1</a>").arg(apiUrl.toHtmlEscaped()));
+    QLabel* urlLabel = new QLabel(tr("<b>API URL:</b> <a href=\"%1\">%1</a>").arg(apiUrl.toHtmlEscaped()));
     urlLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
-    connect(urlLabel, &QLabel::linkActivated, this, [this](const QString &link) { emit debugApiRequested(link); });
+    connect(urlLabel, &QLabel::linkActivated, this, [this](const QString& link) { emit debugApiRequested(link); });
     layout->addWidget(urlLabel);
 
     if (!htmlUrl.isEmpty() && htmlUrl != apiUrl) {
-        QLabel *htmlUrlLabel = new QLabel(tr("<b>HTML URL:</b> <a href=\"%1\">%1</a>").arg(htmlUrl.toHtmlEscaped()));
+        QLabel* htmlUrlLabel = new QLabel(tr("<b>HTML URL:</b> <a href=\"%1\">%1</a>").arg(htmlUrl.toHtmlEscaped()));
         htmlUrlLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
         htmlUrlLabel->setOpenExternalLinks(true);
         layout->addWidget(htmlUrlLabel);
@@ -166,33 +166,33 @@ NotificationWindow::NotificationWindow(const Notification &n, GitHubClient *clie
     layout->addStretch();
 
     // Bottom Actions
-    QHBoxLayout *bottomLayout = new QHBoxLayout();
+    QHBoxLayout* bottomLayout = new QHBoxLayout();
     bottomLayout->addStretch();
 
-    QPushButton *closeBtn = new QPushButton(tr("Close"));
+    QPushButton* closeBtn = new QPushButton(tr("Close"));
     connect(closeBtn, &QPushButton::clicked, this, &KXmlGuiWindow::close);
     bottomLayout->addWidget(closeBtn);
 
-    QPushButton *markDoneBtn = new QPushButton(QIcon::fromTheme("task-complete"), tr("Mark as Done"));
+    QPushButton* markDoneBtn = new QPushButton(QIcon::fromTheme("task-complete"), tr("Mark as Done"));
     connect(markDoneBtn, &QPushButton::clicked, this, &NotificationWindow::onMarkAsDone);
     bottomLayout->addWidget(markDoneBtn);
 
-    QPushButton *closeAndReadBtn = new QPushButton(QIcon::fromTheme("mail-mark-read"), tr("Close and mark as read"));
+    QPushButton* closeAndReadBtn = new QPushButton(QIcon::fromTheme("mail-mark-read"), tr("Close and mark as read"));
     connect(closeAndReadBtn, &QPushButton::clicked, this, &NotificationWindow::onCloseAndMarkAsRead);
     bottomLayout->addWidget(closeAndReadBtn);
 
     if (viewPullRequestAction) {
-        QPushButton *viewPrBtn = new QPushButton(QIcon::fromTheme("vcs-merge-request"), tr("View Pull Request"));
+        QPushButton* viewPrBtn = new QPushButton(QIcon::fromTheme("vcs-merge-request"), tr("View Pull Request"));
         connect(viewPrBtn, &QPushButton::clicked, this, &NotificationWindow::onViewPullRequest);
         bottomLayout->addWidget(viewPrBtn);
     }
     if (viewActionJobAction) {
-        QPushButton *viewActionBtn = new QPushButton(QIcon::fromTheme("system-run"), tr("View Action Job"));
+        QPushButton* viewActionBtn = new QPushButton(QIcon::fromTheme("system-run"), tr("View Action Job"));
         connect(viewActionBtn, &QPushButton::clicked, this, &NotificationWindow::onViewActionJob);
         bottomLayout->addWidget(viewActionBtn);
     }
 
-    QPushButton *viewRawBtn = new QPushButton(QIcon::fromTheme("text-json"), tr("View Raw JSON"));
+    QPushButton* viewRawBtn = new QPushButton(QIcon::fromTheme("text-json"), tr("View Raw JSON"));
     connect(viewRawBtn, &QPushButton::clicked, this, [this]() {
         QJsonObject combined;
         combined["extract"] = m_notification.toJson();
@@ -201,12 +201,12 @@ NotificationWindow::NotificationWindow(const Notification &n, GitHubClient *clie
         QJsonDocument doc(combined);
         QString rawJson = QString::fromUtf8(doc.toJson(QJsonDocument::Indented));
 
-        QDialog *dialog = new QDialog(this);
+        QDialog* dialog = new QDialog(this);
         dialog->setWindowTitle(tr("Raw JSON"));
         dialog->resize(600, 400);
 
-        QVBoxLayout *layout = new QVBoxLayout(dialog);
-        QTextEdit *textEdit = new QTextEdit(dialog);
+        QVBoxLayout* layout = new QVBoxLayout(dialog);
+        QTextEdit* textEdit = new QTextEdit(dialog);
         textEdit->setReadOnly(true);
         textEdit->setPlainText(rawJson);
         layout->addWidget(textEdit);
@@ -257,12 +257,12 @@ void NotificationWindow::onViewRawJson() {
     QJsonDocument doc(combined);
     QString rawJson = QString::fromUtf8(doc.toJson(QJsonDocument::Indented));
 
-    QDialog *dialog = new QDialog(this);
+    QDialog* dialog = new QDialog(this);
     dialog->setWindowTitle(tr("Raw JSON"));
     dialog->resize(600, 400);
 
-    QVBoxLayout *layout = new QVBoxLayout(dialog);
-    QTextEdit *textEdit = new QTextEdit(dialog);
+    QVBoxLayout* layout = new QVBoxLayout(dialog);
+    QTextEdit* textEdit = new QTextEdit(dialog);
     textEdit->setReadOnly(true);
     textEdit->setPlainText(rawJson);
     layout->addWidget(textEdit);
@@ -272,13 +272,13 @@ void NotificationWindow::onViewRawJson() {
 }
 
 void NotificationWindow::onViewPullRequest() {
-    PullRequestWindow *win = new PullRequestWindow(m_notification, m_client, this);
+    PullRequestWindow* win = new PullRequestWindow(m_notification, m_client, this);
     win->setAttribute(Qt::WA_DeleteOnClose);
     win->show();
 }
 
 void NotificationWindow::onViewActionJob() {
-    ActionWindow *win = new ActionWindow(m_notification, m_client, this);
+    ActionWindow* win = new ActionWindow(m_notification, m_client, this);
     win->setAttribute(Qt::WA_DeleteOnClose);
     win->show();
 }

--- a/src/NotificationWindow.h
+++ b/src/NotificationWindow.h
@@ -14,11 +14,11 @@
 class NotificationWindow : public KXmlGuiWindow {
     Q_OBJECT
    public:
-    explicit NotificationWindow(const Notification &notification, GitHubClient *client, QWidget *parent = nullptr);
+    explicit NotificationWindow(const Notification& notification, GitHubClient* client, QWidget* parent = nullptr);
 
    signals:
-    void actionRequested(const QString &actionName, const QString &id, const QString &url);
-    void debugApiRequested(const QString &apiUrl);
+    void actionRequested(const QString& actionName, const QString& id, const QString& url);
+    void debugApiRequested(const QString& apiUrl);
 
    private slots:
     void onOpenUrl();
@@ -32,7 +32,7 @@ class NotificationWindow : public KXmlGuiWindow {
 
    private:
     Notification m_notification;
-    GitHubClient *m_client;
+    GitHubClient* m_client;
 };
 
 #endif  // NOTIFICATIONWINDOW_H

--- a/src/PopupNotification.cpp
+++ b/src/PopupNotification.cpp
@@ -3,13 +3,13 @@
 #include <QApplication>
 #include <QStyle>
 
-PopupNotification::PopupNotification(QWidget *parent) : QWidget(parent) {
+PopupNotification::PopupNotification(QWidget* parent) : QWidget(parent) {
     // Set window flags for a tooltip-like, topmost, frameless window
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Tool);
     setAttribute(Qt::WA_ShowWithoutActivating);
     setAttribute(Qt::WA_DeleteOnClose, false);  // We manage showing/hiding
 
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    QVBoxLayout* mainLayout = new QVBoxLayout(this);
     mainLayout->setContentsMargins(10, 10, 10, 10);
     mainLayout->setSpacing(5);
 
@@ -20,7 +20,7 @@ PopupNotification::PopupNotification(QWidget *parent) : QWidget(parent) {
     mainLayout->addWidget(messageLabel);
 
     // Buttons Layout
-    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    QHBoxLayout* buttonLayout = new QHBoxLayout();
     buttonLayout->setSpacing(10);
     buttonLayout->addStretch();
 
@@ -45,7 +45,7 @@ PopupNotification::PopupNotification(QWidget *parent) : QWidget(parent) {
     setFixedWidth(300);
 }
 
-void PopupNotification::setMessage(const QString &message) {
+void PopupNotification::setMessage(const QString& message) {
     messageLabel->setText(message);
     adjustSize();
 }

--- a/src/PopupNotification.h
+++ b/src/PopupNotification.h
@@ -11,8 +11,8 @@ class PopupNotification : public QWidget {
     Q_OBJECT
 
    public:
-    explicit PopupNotification(QWidget *parent = nullptr);
-    void setMessage(const QString &message);
+    explicit PopupNotification(QWidget* parent = nullptr);
+    void setMessage(const QString& message);
     void setSettingsVisible(bool visible);
 
    signals:
@@ -24,9 +24,9 @@ class PopupNotification : public QWidget {
     void onDismissClicked();
 
    private:
-    QLabel *messageLabel;
-    QPushButton *settingsButton;
-    QPushButton *dismissButton;
+    QLabel* messageLabel;
+    QPushButton* settingsButton;
+    QPushButton* dismissButton;
 };
 
 #endif  // POPUPNOTIFICATION_H

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -7,7 +7,7 @@
 #include <QJsonObject>
 #include <QMessageBox>
 
-PullRequestWindow::PullRequestWindow(const Notification &n, GitHubClient *client, QWidget *parent)
+PullRequestWindow::PullRequestWindow(const Notification& n, GitHubClient* client, QWidget* parent)
     : KXmlGuiWindow(parent, Qt::Window),
       m_notification(n),
       m_client(client),
@@ -97,11 +97,11 @@ void PullRequestWindow::setupUi() {
 void PullRequestWindow::fetchPrDetails() {
     QUrl url(m_notification.url);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
-    QNetworkReply *reply = m_manager->get(request);
+    QNetworkReply* reply = m_manager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onPrDetailsReply(reply); });
 }
 
-void PullRequestWindow::onPrDetailsReply(QNetworkReply *reply) {
+void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -123,14 +123,14 @@ void PullRequestWindow::onPrDetailsReply(QNetworkReply *reply) {
         // Update Metadata
         QStringList labels;
         QJsonArray labelsArray = obj["labels"].toArray();
-        for (const QJsonValue &val : labelsArray) {
+        for (const QJsonValue& val : labelsArray) {
             labels << val.toObject()["name"].toString();
         }
         m_labelsLabel->setText(tr("<b>Labels:</b> %1").arg(labels.isEmpty() ? "None" : labels.join(", ")));
 
         QStringList assignees;
         QJsonArray assigneesArray = obj["assignees"].toArray();
-        for (const QJsonValue &val : assigneesArray) {
+        for (const QJsonValue& val : assigneesArray) {
             assignees << val.toObject()["login"].toString();
         }
         m_assigneesLabel->setText(tr("<b>Assignees:</b> %1").arg(assignees.isEmpty() ? "None" : assignees.join(", ")));
@@ -156,17 +156,17 @@ void PullRequestWindow::fetchComments() {
     if (m_issueCommentsUrl.isEmpty()) return;
     QUrl url(m_issueCommentsUrl);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
-    QNetworkReply *reply = m_manager->get(request);
+    QNetworkReply* reply = m_manager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onCommentsReply(reply); });
 }
 
-void PullRequestWindow::onCommentsReply(QNetworkReply *reply) {
+void PullRequestWindow::onCommentsReply(QNetworkReply* reply) {
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
         QJsonArray array = doc.array();
 
-        for (const QJsonValue &val : array) {
+        for (const QJsonValue& val : array) {
             QJsonObject obj = val.toObject();
             QString author = obj["user"].toObject()["login"].toString();
             QString body = obj["body"].toString();
@@ -181,17 +181,17 @@ void PullRequestWindow::fetchReviewComments() {
     if (m_reviewCommentsUrl.isEmpty()) return;
     QUrl url(m_reviewCommentsUrl);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
-    QNetworkReply *reply = m_manager->get(request);
+    QNetworkReply* reply = m_manager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onReviewCommentsReply(reply); });
 }
 
-void PullRequestWindow::onReviewCommentsReply(QNetworkReply *reply) {
+void PullRequestWindow::onReviewCommentsReply(QNetworkReply* reply) {
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
         QJsonArray array = doc.array();
 
-        for (const QJsonValue &val : array) {
+        for (const QJsonValue& val : array) {
             QJsonObject obj = val.toObject();
             QString author = obj["user"].toObject()["login"].toString();
             QString body = obj["body"].toString();
@@ -211,11 +211,11 @@ void PullRequestWindow::fetchCommits() {
     if (m_commitsUrl.isEmpty()) return;
     QUrl url(m_commitsUrl);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
-    QNetworkReply *reply = m_manager->get(request);
+    QNetworkReply* reply = m_manager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onCommitsReply(reply); });
 }
 
-void PullRequestWindow::onCommitsReply(QNetworkReply *reply) {
+void PullRequestWindow::onCommitsReply(QNetworkReply* reply) {
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -243,11 +243,11 @@ void PullRequestWindow::onCommitsReply(QNetworkReply *reply) {
 void PullRequestWindow::fetchFiles() {
     QUrl url(m_notification.url + "/files");
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
-    QNetworkReply *reply = m_manager->get(request);
+    QNetworkReply* reply = m_manager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onFilesReply(reply); });
 }
 
-void PullRequestWindow::onFilesReply(QNetworkReply *reply) {
+void PullRequestWindow::onFilesReply(QNetworkReply* reply) {
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -264,11 +264,11 @@ void PullRequestWindow::onFilesReply(QNetworkReply *reply) {
             m_filesTable->insertRow(i);
             m_filesTable->setItem(i, 0, new QTableWidgetItem(filename));
 
-            QTableWidgetItem *addItem = new QTableWidgetItem(QString::number(additions));
+            QTableWidgetItem* addItem = new QTableWidgetItem(QString::number(additions));
             addItem->setForeground(QBrush(Qt::darkGreen));
             m_filesTable->setItem(i, 1, addItem);
 
-            QTableWidgetItem *delItem = new QTableWidgetItem(QString::number(deletions));
+            QTableWidgetItem* delItem = new QTableWidgetItem(QString::number(deletions));
             delItem->setForeground(QBrush(Qt::darkRed));
             m_filesTable->setItem(i, 2, delItem);
 
@@ -278,11 +278,11 @@ void PullRequestWindow::onFilesReply(QNetworkReply *reply) {
     reply->deleteLater();
 }
 
-void PullRequestWindow::addCommentToUI(const QString &author, const QString &body, const QString &createdAt) {
+void PullRequestWindow::addCommentToUI(const QString& author, const QString& body, const QString& createdAt) {
     QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
     QString formattedDate = QLocale().toString(dt, QLocale::ShortFormat);
 
-    QLabel *label = new QLabel(tr("<b>%1</b> on %2<br>%3<hr>").arg(author, formattedDate, body));
+    QLabel* label = new QLabel(tr("<b>%1</b> on %2<br>%3<hr>").arg(author, formattedDate, body));
     label->setWordWrap(true);
     label->setTextInteractionFlags(Qt::TextBrowserInteraction);
     label->setOpenExternalLinks(true);
@@ -304,11 +304,11 @@ void PullRequestWindow::onCommentButtonClicked() {
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
 
-    QNetworkReply *reply = m_manager->post(request, data);
+    QNetworkReply* reply = m_manager->post(request, data);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onPostCommentReply(reply); });
 }
 
-void PullRequestWindow::onPostCommentReply(QNetworkReply *reply) {
+void PullRequestWindow::onPostCommentReply(QNetworkReply* reply) {
     m_commentButton->setEnabled(true);
     if (reply->error() == QNetworkReply::NoError) {
         m_replyEdit->clear();

--- a/src/PullRequestWindow.h
+++ b/src/PullRequestWindow.h
@@ -22,59 +22,59 @@ class PullRequestWindow : public KXmlGuiWindow {
     Q_OBJECT
 
    public:
-    explicit PullRequestWindow(const Notification &n, GitHubClient *client, QWidget *parent = nullptr);
+    explicit PullRequestWindow(const Notification& n, GitHubClient* client, QWidget* parent = nullptr);
 
    private slots:
     void fetchPrDetails();
-    void onPrDetailsReply(QNetworkReply *reply);
+    void onPrDetailsReply(QNetworkReply* reply);
 
     void fetchComments();
-    void onCommentsReply(QNetworkReply *reply);
+    void onCommentsReply(QNetworkReply* reply);
 
     void fetchReviewComments();
-    void onReviewCommentsReply(QNetworkReply *reply);
+    void onReviewCommentsReply(QNetworkReply* reply);
 
     void fetchCommits();
-    void onCommitsReply(QNetworkReply *reply);
+    void onCommitsReply(QNetworkReply* reply);
 
     void fetchFiles();
-    void onFilesReply(QNetworkReply *reply);
+    void onFilesReply(QNetworkReply* reply);
 
     void onCommentButtonClicked();
-    void onPostCommentReply(QNetworkReply *reply);
+    void onPostCommentReply(QNetworkReply* reply);
 
    private:
     Notification m_notification;
-    GitHubClient *m_client;
-    QNetworkAccessManager *m_manager;
+    GitHubClient* m_client;
+    QNetworkAccessManager* m_manager;
 
-    QTabWidget *m_tabWidget;
+    QTabWidget* m_tabWidget;
 
     // Conversation Tab
-    QWidget *m_conversationTab;
-    QVBoxLayout *m_conversationLayout;
-    QScrollArea *m_commentsScrollArea;
-    QWidget *m_commentsContainer;
-    QVBoxLayout *m_commentsContainerLayout;
-    QTextEdit *m_replyEdit;
-    QPushButton *m_commentButton;
+    QWidget* m_conversationTab;
+    QVBoxLayout* m_conversationLayout;
+    QScrollArea* m_commentsScrollArea;
+    QWidget* m_commentsContainer;
+    QVBoxLayout* m_commentsContainerLayout;
+    QTextEdit* m_replyEdit;
+    QPushButton* m_commentButton;
 
     // Commits Tab
-    QWidget *m_commitsTab;
-    QVBoxLayout *m_commitsLayout;
-    QTableWidget *m_commitsTable;
+    QWidget* m_commitsTab;
+    QVBoxLayout* m_commitsLayout;
+    QTableWidget* m_commitsTable;
 
     // Changed Files Tab
-    QWidget *m_filesTab;
-    QVBoxLayout *m_filesLayout;
-    QTableWidget *m_filesTable;
+    QWidget* m_filesTab;
+    QVBoxLayout* m_filesLayout;
+    QTableWidget* m_filesTable;
 
     // Metadata Tab
-    QWidget *m_metadataTab;
-    QVBoxLayout *m_metadataLayout;
-    QLabel *m_labelsLabel;
-    QLabel *m_assigneesLabel;
-    QLabel *m_milestoneLabel;
+    QWidget* m_metadataTab;
+    QVBoxLayout* m_metadataLayout;
+    QLabel* m_labelsLabel;
+    QLabel* m_assigneesLabel;
+    QLabel* m_milestoneLabel;
 
     QString m_commentsUrl;
     QString m_reviewCommentsUrl;
@@ -82,7 +82,7 @@ class PullRequestWindow : public KXmlGuiWindow {
     QString m_issueCommentsUrl;
 
     void setupUi();
-    void addCommentToUI(const QString &author, const QString &body, const QString &createdAt);
+    void addCommentToUI(const QString& author, const QString& body, const QString& createdAt);
 };
 
 #endif  // PULLREQUESTWINDOW_H

--- a/src/RepoListWindow.cpp
+++ b/src/RepoListWindow.cpp
@@ -27,7 +27,7 @@
 
 #include "NewIssueDialog.h"
 
-RepoListWindow::RepoListWindow(GitHubClient *client, QWidget *parent)
+RepoListWindow::RepoListWindow(GitHubClient* client, QWidget* parent)
     : KXmlGuiWindow(parent),
       m_client(client),
       m_table(nullptr),
@@ -62,7 +62,7 @@ void RepoListWindow::setupUI() {
     m_table->setSortingEnabled(true);
     connect(m_table, &QWidget::customContextMenuRequested, this, &RepoListWindow::onCustomContextMenuRequested);
 
-    QHeaderView *header = m_table->horizontalHeader();
+    QHeaderView* header = m_table->horizontalHeader();
     header->setSectionResizeMode(QHeaderView::ResizeToContents);
     header->setStretchLastSection(true);
 
@@ -75,32 +75,32 @@ void RepoListWindow::setupUI() {
     m_toolbar->setObjectName("RepoListMainToolBar");
     m_toolbar->setMovable(false);
 
-    QAction *refreshAction = new QAction(QIcon::fromTheme("view-refresh"), tr("Refresh"), this);
+    QAction* refreshAction = new QAction(QIcon::fromTheme("view-refresh"), tr("Refresh"), this);
     connect(refreshAction, &QAction::triggered, this, &RepoListWindow::onRefreshClicked);
     m_toolbar->addAction(refreshAction);
 
-    QAction *exportAction = new QAction(QIcon::fromTheme("document-export"), tr("Export to CSV"), this);
+    QAction* exportAction = new QAction(QIcon::fromTheme("document-export"), tr("Export to CSV"), this);
     connect(exportAction, &QAction::triggered, this, &RepoListWindow::onExportClicked);
     m_toolbar->addAction(exportAction);
 
-    QAction *closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
+    QAction* closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
     closeAction->setShortcut(QKeySequence::Close);
     connect(closeAction, &QAction::triggered, this, &RepoListWindow::close);
 
-    QMenuBar *menuBarWidget = menuBar();
-    QMenu *fileMenu = menuBarWidget->addMenu(tr("&File"));
+    QMenuBar* menuBarWidget = menuBar();
+    QMenu* fileMenu = menuBarWidget->addMenu(tr("&File"));
     fileMenu->addAction(exportAction);
     fileMenu->addSeparator();
     fileMenu->addAction(closeAction);
 
-    QMenu *editMenu = menuBarWidget->addMenu(tr("&Edit"));
-    QAction *copyAction = new QAction(QIcon::fromTheme("edit-copy"), tr("Copy URL"), this);
+    QMenu* editMenu = menuBarWidget->addMenu(tr("&Edit"));
+    QAction* copyAction = new QAction(QIcon::fromTheme("edit-copy"), tr("Copy URL"), this);
     copyAction->setShortcut(QKeySequence::Copy);
     connect(copyAction, &QAction::triggered, this, [this]() {
-        QList<QTableWidgetItem *> items = m_table->selectedItems();
+        QList<QTableWidgetItem*> items = m_table->selectedItems();
         if (!items.isEmpty()) {
             int row = items.first()->row();
-            QTableWidgetItem *urlItem = m_table->item(row, 7);  // URL is column 7
+            QTableWidgetItem* urlItem = m_table->item(row, 7);  // URL is column 7
             if (urlItem) {
                 QApplication::clipboard()->setText(urlItem->text());
             }
@@ -108,7 +108,7 @@ void RepoListWindow::setupUI() {
     });
     editMenu->addAction(copyAction);
 
-    QMenu *viewMenu = menuBarWidget->addMenu(tr("&View"));
+    QMenu* viewMenu = menuBarWidget->addMenu(tr("&View"));
     refreshAction->setShortcut(QKeySequence::Refresh);
     viewMenu->addAction(refreshAction);
 
@@ -149,7 +149,7 @@ void RepoListWindow::onExportClicked() {
     for (int row = 0; row < m_table->rowCount(); ++row) {
         QStringList rowData;
         for (int col = 0; col < m_table->columnCount(); ++col) {
-            QTableWidgetItem *item = m_table->item(row, col);
+            QTableWidgetItem* item = m_table->item(row, col);
             QString text = item ? item->text() : "";
             rowData << "\"" + text.replace("\"", "\"\"") + "\"";
         }
@@ -160,8 +160,8 @@ void RepoListWindow::onExportClicked() {
     m_statusBar->showMessage(tr("Exported to %1").arg(fileName), 5000);
 }
 
-void RepoListWindow::onReposReceived(const QJsonArray &repos, const QString &nextPageUrl) {
-    for (const QJsonValue &val : repos) {
+void RepoListWindow::onReposReceived(const QJsonArray& repos, const QString& nextPageUrl) {
+    for (const QJsonValue& val : repos) {
         m_allRepos.append(val);
     }
 
@@ -176,24 +176,24 @@ void RepoListWindow::onReposReceived(const QJsonArray &repos, const QString &nex
     }
 }
 
-void RepoListWindow::addReposToTable(const QJsonArray &repos) {
+void RepoListWindow::addReposToTable(const QJsonArray& repos) {
     m_table->setSortingEnabled(false);
     m_table->setRowCount(repos.size());
 
     for (int i = 0; i < repos.size(); ++i) {
         QJsonObject repo = repos[i].toObject();
 
-        QTableWidgetItem *nameItem = new QTableWidgetItem(repo["name"].toString());
-        QTableWidgetItem *ownerItem = new QTableWidgetItem(repo["owner"].toObject()["login"].toString());
-        QTableWidgetItem *visItem = new QTableWidgetItem(repo["visibility"].toString());
+        QTableWidgetItem* nameItem = new QTableWidgetItem(repo["name"].toString());
+        QTableWidgetItem* ownerItem = new QTableWidgetItem(repo["owner"].toObject()["login"].toString());
+        QTableWidgetItem* visItem = new QTableWidgetItem(repo["visibility"].toString());
 
-        QTableWidgetItem *starsItem = new QTableWidgetItem();
+        QTableWidgetItem* starsItem = new QTableWidgetItem();
         starsItem->setData(Qt::DisplayRole, repo["stargazers_count"].toInt());
 
-        QTableWidgetItem *forksItem = new QTableWidgetItem();
+        QTableWidgetItem* forksItem = new QTableWidgetItem();
         forksItem->setData(Qt::DisplayRole, repo["forks_count"].toInt());
 
-        QTableWidgetItem *issuesItem = new QTableWidgetItem();
+        QTableWidgetItem* issuesItem = new QTableWidgetItem();
         issuesItem->setData(Qt::DisplayRole, repo["open_issues_count"].toInt());
 
         QString updatedStr = repo["updated_at"].toString();
@@ -201,9 +201,9 @@ void RepoListWindow::addReposToTable(const QJsonArray &repos) {
 
         class DateTableItem : public QTableWidgetItem {
            public:
-            DateTableItem(const QString &text, const QDateTime &date) : QTableWidgetItem(text), m_date(date) {}
-            bool operator<(const QTableWidgetItem &other) const override {
-                const DateTableItem *otherDateItem = dynamic_cast<const DateTableItem *>(&other);
+            DateTableItem(const QString& text, const QDateTime& date) : QTableWidgetItem(text), m_date(date) {}
+            bool operator<(const QTableWidgetItem& other) const override {
+                const DateTableItem* otherDateItem = dynamic_cast<const DateTableItem*>(&other);
                 if (otherDateItem) {
                     return m_date < otherDateItem->m_date;
                 }
@@ -214,9 +214,9 @@ void RepoListWindow::addReposToTable(const QJsonArray &repos) {
             QDateTime m_date;
         };
 
-        QTableWidgetItem *updatedItem = new DateTableItem(QLocale::system().toString(dt, QLocale::ShortFormat), dt);
+        QTableWidgetItem* updatedItem = new DateTableItem(QLocale::system().toString(dt, QLocale::ShortFormat), dt);
 
-        QTableWidgetItem *urlItem = new QTableWidgetItem(repo["html_url"].toString());
+        QTableWidgetItem* urlItem = new QTableWidgetItem(repo["html_url"].toString());
 
         m_table->setItem(i, 0, nameItem);
         m_table->setItem(i, 1, ownerItem);
@@ -245,23 +245,23 @@ void RepoListWindow::updateTimerLabel() {
     }
 }
 
-void RepoListWindow::onCustomContextMenuRequested(const QPoint &pos) {
-    QTableWidgetItem *item = m_table->itemAt(pos);
+void RepoListWindow::onCustomContextMenuRequested(const QPoint& pos) {
+    QTableWidgetItem* item = m_table->itemAt(pos);
     if (!item) return;
 
     int row = item->row();
-    QTableWidgetItem *urlItem = m_table->item(row, 7);  // URL is col 7
+    QTableWidgetItem* urlItem = m_table->item(row, 7);  // URL is col 7
     if (!urlItem) return;
 
     QString url = urlItem->text();
 
     QMenu menu(this);
-    QAction *openAction = menu.addAction(QIcon::fromTheme("internet-web-browser"), tr("Open in Browser"));
-    QAction *copyAction = menu.addAction(QIcon::fromTheme("edit-copy"), tr("Copy URL"));
+    QAction* openAction = menu.addAction(QIcon::fromTheme("internet-web-browser"), tr("Open in Browser"));
+    QAction* copyAction = menu.addAction(QIcon::fromTheme("edit-copy"), tr("Copy URL"));
     menu.addSeparator();
-    QAction *newIssueAction = menu.addAction(QIcon::fromTheme("document-new"), tr("New Issue..."));
+    QAction* newIssueAction = menu.addAction(QIcon::fromTheme("document-new"), tr("New Issue..."));
 
-    QAction *selected = menu.exec(m_table->viewport()->mapToGlobal(pos));
+    QAction* selected = menu.exec(m_table->viewport()->mapToGlobal(pos));
 
     if (selected == openAction) {
         QDesktopServices::openUrl(QUrl(url));
@@ -269,7 +269,7 @@ void RepoListWindow::onCustomContextMenuRequested(const QPoint &pos) {
         QApplication::clipboard()->setText(url);
     } else if (selected == newIssueAction) {
         if (m_client) {
-            NewIssueDialog *dialog = new NewIssueDialog(m_client, this);
+            NewIssueDialog* dialog = new NewIssueDialog(m_client, this);
             dialog->setAttribute(Qt::WA_DeleteOnClose);
             QString repoName = QUrl(url).path().mid(1);  // removes leading slash
             dialog->setInitialRepo(repoName);
@@ -278,7 +278,7 @@ void RepoListWindow::onCustomContextMenuRequested(const QPoint &pos) {
     }
 }
 
-void RepoListWindow::onError(const QString &error) {
+void RepoListWindow::onError(const QString& error) {
     if (m_statusBar) {
         m_statusBar->showMessage(tr("Error fetching repositories: %1").arg(error), 5000);
     }

--- a/src/RepoListWindow.h
+++ b/src/RepoListWindow.h
@@ -16,28 +16,28 @@ class RepoListWindow : public KXmlGuiWindow {
     Q_OBJECT
 
    public:
-    explicit RepoListWindow(GitHubClient *client, QWidget *parent = nullptr);
+    explicit RepoListWindow(GitHubClient* client, QWidget* parent = nullptr);
 
    private slots:
     void onRefreshClicked();
     void onExportClicked();
-    void onReposReceived(const QJsonArray &repos, const QString &nextPageUrl);
+    void onReposReceived(const QJsonArray& repos, const QString& nextPageUrl);
     void updateTimerLabel();
-    void onCustomContextMenuRequested(const QPoint &pos);
-    void onError(const QString &error);
+    void onCustomContextMenuRequested(const QPoint& pos);
+    void onError(const QString& error);
 
    private:
     void setupUI();
     void loadCache();
     void saveCache();
-    void addReposToTable(const QJsonArray &repos);
+    void addReposToTable(const QJsonArray& repos);
 
-    GitHubClient *m_client;
-    QTableWidget *m_table;
-    QToolBar *m_toolbar;
-    QStatusBar *m_statusBar;
-    QLabel *m_timerLabel;
-    QTimer *m_updateTimer;
+    GitHubClient* m_client;
+    QTableWidget* m_table;
+    QToolBar* m_toolbar;
+    QStatusBar* m_statusBar;
+    QLabel* m_timerLabel;
+    QTimer* m_updateTimer;
     QDateTime m_lastRefresh;
     QJsonArray m_allRepos;
 };

--- a/src/SecureString.h
+++ b/src/SecureString.h
@@ -18,20 +18,20 @@ class SecureString {
    public:
     SecureString() = default;
 
-    explicit SecureString(const QString &str) { set(str); }
+    explicit SecureString(const QString& str) { set(str); }
 
     ~SecureString() { clear(); }
 
     // Disable copy
-    SecureString(const SecureString &) = delete;
-    SecureString &operator=(const SecureString &) = delete;
+    SecureString(const SecureString&) = delete;
+    SecureString& operator=(const SecureString&) = delete;
 
     // Enable move
-    SecureString(SecureString &&other) noexcept : m_data(std::move(other.m_data)) {
+    SecureString(SecureString&& other) noexcept : m_data(std::move(other.m_data)) {
         // Since m_data was moved, other.m_data is now empty.
     }
 
-    SecureString &operator=(SecureString &&other) noexcept {
+    SecureString& operator=(SecureString&& other) noexcept {
         if (this != &other) {
             clear();
             m_data = std::move(other.m_data);
@@ -39,7 +39,7 @@ class SecureString {
         return *this;
     }
 
-    void set(const QString &str) {
+    void set(const QString& str) {
         clear();
         QByteArray bytes = str.toUtf8();
         if (bytes.isEmpty()) return;
@@ -54,7 +54,7 @@ class SecureString {
         std::memcpy(m_data.data(), bytes.constData(), bytes.size());
 
         // Attempt to clear temporary QByteArray buffer
-        volatile char *p = bytes.data();
+        volatile char* p = bytes.data();
         size_t s = bytes.size();
         while (s--) *p++ = 0;
     }
@@ -80,7 +80,7 @@ class SecureString {
             munlock(m_data.data(), m_data.size());
 #endif
 
-            volatile char *p = m_data.data();
+            volatile char* p = m_data.data();
             size_t s = m_data.size();
             while (s--) *p++ = 0;
             m_data.clear();

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -18,15 +18,15 @@
 #include "RulesDialog.h"
 #include "WalletManager.h"
 
-SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent), testClient(nullptr) {
+SettingsDialog::SettingsDialog(QWidget* parent) : QDialog(parent), testClient(nullptr) {
     setWindowTitle("Settings");
 
-    QVBoxLayout *layout = new QVBoxLayout(this);
+    QVBoxLayout* layout = new QVBoxLayout(this);
 
-    QLabel *label = new QLabel("GitHub Personal Access Token:", this);
+    QLabel* label = new QLabel("GitHub Personal Access Token:", this);
     layout->addWidget(label);
 
-    QLabel *helpLabel = new QLabel(
+    QLabel* helpLabel = new QLabel(
         "<small>Classic PAT scopes: <code>repo</code>, <code>read:org</code>, "
         "<code>notifications</code>.<br>Fine-grained token: <code>Issues</code> & <code>Pull requests</code> "
         "(Read/Write), <code>Metadata</code> (Read).</small>",
@@ -35,7 +35,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent), testClient(nu
     helpLabel->setStyleSheet("color: gray;");
     layout->addWidget(helpLabel);
 
-    QHBoxLayout *tokenLayout = new QHBoxLayout();
+    QHBoxLayout* tokenLayout = new QHBoxLayout();
     tokenEdit = new QLineEdit(this);
     tokenEdit->setEchoMode(QLineEdit::Password);
 
@@ -43,7 +43,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent), testClient(nu
     tokenEdit->setEnabled(false);
     tokenEdit->setPlaceholderText("Loading...");
 
-    QFutureWatcher<QString> *watcher = new QFutureWatcher<QString>(this);
+    QFutureWatcher<QString>* watcher = new QFutureWatcher<QString>(this);
     connect(watcher, &QFutureWatcher<QString>::finished, this, [this, watcher]() {
         tokenEdit->setText(watcher->result());
         tokenEdit->setEnabled(true);
@@ -65,7 +65,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent), testClient(nu
     layout->addWidget(statusLabel);
 
     // Interval
-    QLabel *intervalLabel = new QLabel("Refresh Interval (minutes):", this);
+    QLabel* intervalLabel = new QLabel("Refresh Interval (minutes):", this);
     layout->addWidget(intervalLabel);
 
     intervalCombo = new QComboBox(this);
@@ -80,7 +80,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent), testClient(nu
     layout->addWidget(intervalCombo);
 
     // Data Loading Strategy
-    QLabel *dataLabel = new QLabel("Data Loading Strategy:", this);
+    QLabel* dataLabel = new QLabel("Data Loading Strategy:", this);
     layout->addWidget(dataLabel);
 
     dataOptionCombo = new QComboBox(this);
@@ -97,7 +97,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent), testClient(nu
     layout->addWidget(dataOptionCombo);
 
     // Notifications configuration
-    QLabel *summaryThresholdLabel = new QLabel("Max notifications before summary:", this);
+    QLabel* summaryThresholdLabel = new QLabel("Max notifications before summary:", this);
     layout->addWidget(summaryThresholdLabel);
 
     summaryThresholdCombo = new QComboBox(this);
@@ -111,7 +111,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent), testClient(nu
     }
     layout->addWidget(summaryThresholdCombo);
 
-    QLabel *notificationDelayLabel = new QLabel("Notification delay (ms):", this);
+    QLabel* notificationDelayLabel = new QLabel("Notification delay (ms):", this);
     layout->addWidget(notificationDelayLabel);
 
     notificationDelayCombo = new QComboBox(this);
@@ -125,7 +125,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent), testClient(nu
     }
     layout->addWidget(notificationDelayCombo);
 
-    QLabel *trayUnreadLimitLabel = new QLabel("Max unread notifications in tray:", this);
+    QLabel* trayUnreadLimitLabel = new QLabel("Max unread notifications in tray:", this);
     layout->addWidget(trayUnreadLimitLabel);
 
     trayUnreadLimitCombo = new QComboBox(this);
@@ -154,7 +154,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent), testClient(nu
     notifyReadCheckBox = new QCheckBox("Notify on read notifications", this);
     notifyReadCheckBox->setChecked(getNotifyRead());
     layout->addWidget(notifyReadCheckBox);
-    QPushButton *rulesBtn = new QPushButton(tr("Manage Notification Rules..."), this);
+    QPushButton* rulesBtn = new QPushButton(tr("Manage Notification Rules..."), this);
     connect(rulesBtn, &QPushButton::clicked, this, [this]() {
         RulesDialog dialog(this);
         dialog.exec();
@@ -162,10 +162,10 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent), testClient(nu
     layout->addWidget(rulesBtn);
 
     // Notifications Service
-    QLabel *serviceLabel = new QLabel("Notification Service:", this);
+    QLabel* serviceLabel = new QLabel("Notification Service:", this);
     layout->addWidget(serviceLabel);
 
-    QPushButton *installServiceBtn = new QPushButton("Install kgithub-notify.notifyrc", this);
+    QPushButton* installServiceBtn = new QPushButton("Install kgithub-notify.notifyrc", this);
     connect(installServiceBtn, &QPushButton::clicked, this, &SettingsDialog::installNotifyRc);
     layout->addWidget(installServiceBtn);
 
@@ -190,9 +190,9 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent), testClient(nu
 
     connect(autostartCheckBox, &QCheckBox::toggled, startMinimizedCheckBox, &QCheckBox::setEnabled);
 
-    QHBoxLayout *buttonLayout = new QHBoxLayout();
-    QPushButton *saveButton = new QPushButton("Save", this);
-    QPushButton *cancelButton = new QPushButton("Cancel", this);
+    QHBoxLayout* buttonLayout = new QHBoxLayout();
+    QPushButton* saveButton = new QPushButton("Save", this);
+    QPushButton* cancelButton = new QPushButton("Cancel", this);
 
     buttonLayout->addWidget(saveButton);
     buttonLayout->addWidget(cancelButton);
@@ -327,7 +327,7 @@ void SettingsDialog::onTestClicked() {
     testClient->verifyToken();
 }
 
-void SettingsDialog::onVerificationResult(bool valid, const QString &message) {
+void SettingsDialog::onVerificationResult(bool valid, const QString& message) {
     testButton->setEnabled(true);
     statusLabel->setText(message);
     if (valid) {

--- a/src/SettingsDialog.h
+++ b/src/SettingsDialog.h
@@ -14,7 +14,7 @@ class QCheckBox;
 class SettingsDialog : public QDialog {
     Q_OBJECT
    public:
-    explicit SettingsDialog(QWidget *parent = nullptr);
+    explicit SettingsDialog(QWidget* parent = nullptr);
     enum GetDataOption { Manual, FillScreen, GetAll, Infinite };
     Q_ENUM(GetDataOption)
 
@@ -33,26 +33,26 @@ class SettingsDialog : public QDialog {
    private slots:
     void saveSettings();
     void onTestClicked();
-    void onVerificationResult(bool valid, const QString &message);
+    void onVerificationResult(bool valid, const QString& message);
     void installNotifyRc();
 
    private:
     void updateAutostartEntry();
     bool isAutostartEnabled();
 
-    QLineEdit *tokenEdit;
-    QComboBox *intervalCombo;
-    QComboBox *dataOptionCombo;
-    QComboBox *summaryThresholdCombo;
-    QComboBox *notificationDelayCombo;
-    QComboBox *trayUnreadLimitCombo;
-    QCheckBox *autostartCheckBox;
-    QCheckBox *startMinimizedCheckBox;
-    QCheckBox *notifyOnceCheckBox;
-    QCheckBox *notifyReadCheckBox;
-    QPushButton *testButton;
-    QLabel *statusLabel;
-    GitHubClient *testClient;
+    QLineEdit* tokenEdit;
+    QComboBox* intervalCombo;
+    QComboBox* dataOptionCombo;
+    QComboBox* summaryThresholdCombo;
+    QComboBox* notificationDelayCombo;
+    QComboBox* trayUnreadLimitCombo;
+    QCheckBox* autostartCheckBox;
+    QCheckBox* startMinimizedCheckBox;
+    QCheckBox* notifyOnceCheckBox;
+    QCheckBox* notifyReadCheckBox;
+    QPushButton* testButton;
+    QLabel* statusLabel;
+    GitHubClient* testClient;
 };
 
 #endif  // SETTINGSDIALOG_H

--- a/src/WalletManager.cpp
+++ b/src/WalletManager.cpp
@@ -48,12 +48,12 @@ class WalletLoader : public QObject {
     }
 
    private:
-    KWallet::Wallet *wallet = nullptr;
+    KWallet::Wallet* wallet = nullptr;
     QFutureInterface<QString> interface;
 };
 
 QString WalletManager::loadToken() {
-    KWallet::Wallet *wallet =
+    KWallet::Wallet* wallet =
         KWallet::Wallet::openWallet(KWallet::Wallet::LocalWallet(), 0, KWallet::Wallet::Synchronous);
     if (wallet) {
         if (!wallet->hasFolder(FOLDER_NAME)) {
@@ -69,12 +69,12 @@ QString WalletManager::loadToken() {
 }
 
 QFuture<QString> WalletManager::loadTokenAsync() {
-    WalletLoader *loader = new WalletLoader();
+    WalletLoader* loader = new WalletLoader();
     return loader->start();
 }
 
-void WalletManager::saveToken(const QString &token) {
-    KWallet::Wallet *wallet =
+void WalletManager::saveToken(const QString& token) {
+    KWallet::Wallet* wallet =
         KWallet::Wallet::openWallet(KWallet::Wallet::LocalWallet(), 0, KWallet::Wallet::Synchronous);
     if (wallet) {
         if (!wallet->hasFolder(FOLDER_NAME)) {

--- a/src/WalletManager.h
+++ b/src/WalletManager.h
@@ -8,7 +8,7 @@ class WalletManager {
    public:
     static QString loadToken();
     static QFuture<QString> loadTokenAsync();
-    static void saveToken(const QString &token);
+    static void saveToken(const QString& token);
 };
 
 #endif  // WALLETMANAGER_H

--- a/src/WorkItemWindow.cpp
+++ b/src/WorkItemWindow.cpp
@@ -20,8 +20,8 @@
 #include <QToolBar>
 #include <QUrl>
 
-WorkItemWindow::WorkItemWindow(GitHubClient *client, const QString &windowTitle, EndpointType endpointType,
-                               const QString &baseQuery, QWidget *parent)
+WorkItemWindow::WorkItemWindow(GitHubClient* client, const QString& windowTitle, EndpointType endpointType,
+                               const QString& baseQuery, QWidget* parent)
     : KXmlGuiWindow(parent),
       m_client(client),
       m_windowTitle(windowTitle),
@@ -63,39 +63,39 @@ void WorkItemWindow::setupUi() {
     setupGUI(Default, ":/kgithub-notifyui.rc");
 
     // Actions
-    QAction *exportCsvAction = new QAction(tr("Export to CSV"), this);
+    QAction* exportCsvAction = new QAction(tr("Export to CSV"), this);
     connect(exportCsvAction, &QAction::triggered, this, &WorkItemWindow::exportToCsv);
-    QAction *exportJsonAction = new QAction(tr("Export to JSON"), this);
+    QAction* exportJsonAction = new QAction(tr("Export to JSON"), this);
     connect(exportJsonAction, &QAction::triggered, this, &WorkItemWindow::exportToJson);
-    QAction *refreshAction = new QAction(tr("Refresh"), this);
+    QAction* refreshAction = new QAction(tr("Refresh"), this);
     connect(refreshAction, &QAction::triggered, this, [this]() {
         m_table->setRowCount(0);  // Give immediate visual feedback of refresh
         loadData(1);
     });
-    QAction *closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
+    QAction* closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
     closeAction->setShortcut(QKeySequence::Close);
     connect(closeAction, &QAction::triggered, this, &WorkItemWindow::close);
 
     // Menu Bar
-    QMenuBar *menuBarWidget = menuBar();
-    QMenu *fileMenu = menuBarWidget->addMenu(tr("&File"));
+    QMenuBar* menuBarWidget = menuBar();
+    QMenu* fileMenu = menuBarWidget->addMenu(tr("&File"));
     fileMenu->addAction(exportCsvAction);
     fileMenu->addAction(exportJsonAction);
     fileMenu->addSeparator();
     fileMenu->addAction(closeAction);
 
-    QMenu *editMenu = menuBarWidget->addMenu(tr("&Edit"));
+    QMenu* editMenu = menuBarWidget->addMenu(tr("&Edit"));
     m_copyAction = new QAction(QIcon::fromTheme("edit-copy"), tr("Copy Link"), this);
     m_copyAction->setShortcut(QKeySequence::Copy);
     connect(m_copyAction, &QAction::triggered, this, &WorkItemWindow::copyLink);
     editMenu->addAction(m_copyAction);
 
-    QMenu *viewMenu = menuBarWidget->addMenu(tr("&View"));
+    QMenu* viewMenu = menuBarWidget->addMenu(tr("&View"));
     refreshAction->setShortcut(QKeySequence::Refresh);
     viewMenu->addAction(refreshAction);
 
     // Tool Bar
-    QToolBar *toolBar = addToolBar(tr("Main Toolbar"));
+    QToolBar* toolBar = addToolBar(tr("Main Toolbar"));
     toolBar->setObjectName("WorkItemMainToolBar");
     toolBar->addAction(refreshAction);
     toolBar->addSeparator();
@@ -157,7 +157,7 @@ void WorkItemWindow::loadData(int page) {
     m_manager->get(request);
 }
 
-void WorkItemWindow::onReplyFinished(QNetworkReply *reply) {
+void WorkItemWindow::onReplyFinished(QNetworkReply* reply) {
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -198,7 +198,7 @@ void WorkItemWindow::onReplyFinished(QNetworkReply *reply) {
     reply->deleteLater();
 }
 
-void WorkItemWindow::appendRow(const QJsonObject &item) {
+void WorkItemWindow::appendRow(const QJsonObject& item) {
     int row = m_table->rowCount();
     m_table->insertRow(row);
 
@@ -215,11 +215,11 @@ void WorkItemWindow::appendRow(const QJsonObject &item) {
         QString repoUrl = item["repository_url"].toString();
         QString repo = repoUrl.section('/', -2);  // Gets owner/repo
 
-        QTableWidgetItem *repoItem = new QTableWidgetItem(repo);
-        QTableWidgetItem *titleItem = new QTableWidgetItem(title);
-        QTableWidgetItem *stateItem = new QTableWidgetItem(state);
-        QTableWidgetItem *authorItem = new QTableWidgetItem(author);
-        QTableWidgetItem *createdItem = new QTableWidgetItem(createdAt);
+        QTableWidgetItem* repoItem = new QTableWidgetItem(repo);
+        QTableWidgetItem* titleItem = new QTableWidgetItem(title);
+        QTableWidgetItem* stateItem = new QTableWidgetItem(state);
+        QTableWidgetItem* authorItem = new QTableWidgetItem(author);
+        QTableWidgetItem* createdItem = new QTableWidgetItem(createdAt);
 
         // Store the URL in the title item for easy access later
         titleItem->setData(Qt::UserRole, htmlUrl);
@@ -237,11 +237,11 @@ void WorkItemWindow::appendRow(const QJsonObject &item) {
         QString owner = item["owner"].toObject()["login"].toString();
         QString createdAt = item["created_at"].toString();
 
-        QTableWidgetItem *repoItem = new QTableWidgetItem(fullName);
-        QTableWidgetItem *descItem = new QTableWidgetItem(description);
-        QTableWidgetItem *langItem = new QTableWidgetItem(language);
-        QTableWidgetItem *ownerItem = new QTableWidgetItem(owner);
-        QTableWidgetItem *createdItem = new QTableWidgetItem(createdAt);
+        QTableWidgetItem* repoItem = new QTableWidgetItem(fullName);
+        QTableWidgetItem* descItem = new QTableWidgetItem(description);
+        QTableWidgetItem* langItem = new QTableWidgetItem(language);
+        QTableWidgetItem* ownerItem = new QTableWidgetItem(owner);
+        QTableWidgetItem* createdItem = new QTableWidgetItem(createdAt);
 
         // Store the URL in the repo item
         repoItem->setData(Qt::UserRole, htmlUrl);
@@ -278,7 +278,7 @@ void WorkItemWindow::exportToCsv() {
     for (int row = 0; row < m_table->rowCount(); ++row) {
         QStringList rowData;
         for (int col = 0; col < m_table->columnCount(); ++col) {
-            QTableWidgetItem *item = m_table->item(row, col);
+            QTableWidgetItem* item = m_table->item(row, col);
             QString text = item ? item->text() : "";
             text.replace("\"", "\"\"");  // Escape quotes
             rowData << QString("\"%1\"").arg(text);
@@ -307,7 +307,7 @@ void WorkItemWindow::exportToJson() {
         QJsonObject jsonObj;
         for (int col = 0; col < m_table->columnCount(); ++col) {
             QString header = m_table->horizontalHeaderItem(col)->text();
-            QTableWidgetItem *item = m_table->item(row, col);
+            QTableWidgetItem* item = m_table->item(row, col);
             jsonObj[header] = item ? item->text() : "";
         }
         jsonObj["URL"] = getHtmlUrlForRow(row);
@@ -319,7 +319,7 @@ void WorkItemWindow::exportToJson() {
     file.close();
 }
 
-void WorkItemWindow::onCustomContextMenuRequested(const QPoint &pos) {
+void WorkItemWindow::onCustomContextMenuRequested(const QPoint& pos) {
     QModelIndex index = m_table->indexAt(pos);
     if (!index.isValid()) return;
 
@@ -329,7 +329,7 @@ void WorkItemWindow::onCustomContextMenuRequested(const QPoint &pos) {
     menu.exec(m_table->viewport()->mapToGlobal(pos));
 }
 
-void WorkItemWindow::onItemDoubleClicked(QTableWidgetItem *item) {
+void WorkItemWindow::onItemDoubleClicked(QTableWidgetItem* item) {
     if (item) {
         openInBrowser();
     }
@@ -358,7 +358,7 @@ void WorkItemWindow::copyLink() {
 }
 
 QString WorkItemWindow::getHtmlUrlForRow(int row) const {
-    QTableWidgetItem *item = m_table->item(row, (m_endpointType == EndpointIssues) ? 1 : 0);
+    QTableWidgetItem* item = m_table->item(row, (m_endpointType == EndpointIssues) ? 1 : 0);
     if (item) {
         return item->data(Qt::UserRole).toString();
     }

--- a/src/WorkItemWindow.h
+++ b/src/WorkItemWindow.h
@@ -19,35 +19,35 @@ class WorkItemWindow : public KXmlGuiWindow {
    public:
     enum EndpointType { EndpointIssues, EndpointRepositories };
 
-    explicit WorkItemWindow(GitHubClient *client, const QString &windowTitle, EndpointType endpointType,
-                            const QString &baseQuery, QWidget *parent = nullptr);
+    explicit WorkItemWindow(GitHubClient* client, const QString& windowTitle, EndpointType endpointType,
+                            const QString& baseQuery, QWidget* parent = nullptr);
     ~WorkItemWindow();
 
    private slots:
-    void onReplyFinished(QNetworkReply *reply);
+    void onReplyFinished(QNetworkReply* reply);
     void exportToCsv();
     void exportToJson();
-    void onCustomContextMenuRequested(const QPoint &pos);
-    void onItemDoubleClicked(QTableWidgetItem *item);
+    void onCustomContextMenuRequested(const QPoint& pos);
+    void onItemDoubleClicked(QTableWidgetItem* item);
     void openInBrowser();
     void copyLink();
 
    private:
-    GitHubClient *m_client;
+    GitHubClient* m_client;
     QString m_windowTitle;
     EndpointType m_endpointType;
     QString m_baseQuery;
     int m_currentPage;
     QJsonArray m_allData;
-    QTableWidget *m_table;
-    QLabel *m_statusLabel;
-    QAction *m_openAction;
-    QAction *m_copyAction;
-    QNetworkAccessManager *m_manager;
+    QTableWidget* m_table;
+    QLabel* m_statusLabel;
+    QAction* m_openAction;
+    QAction* m_copyAction;
+    QNetworkAccessManager* m_manager;
 
     void setupUi();
     void loadData(int page = 1);
-    void appendRow(const QJsonObject &item);
+    void appendRow(const QJsonObject& item);
     QString getHtmlUrlForRow(int row) const;
     QString getCacheFilePath() const;
     void loadCache();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@
 #define KGHN_APP_VERSION "dev"
 #endif
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     QCoreApplication::setOrganizationName("arran4");
     QCoreApplication::setOrganizationDomain("arran4.com");
     QCoreApplication::setApplicationName("kgithub-notify");
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
     QString desktopFileName = QGuiApplication::desktopFileName() + ".desktop";
     bool desktopFileFound = false;
     QStringList appPaths = QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation);
-    for (const QString &path : appPaths) {
+    for (const QString& path : appPaths) {
         if (QFileInfo::exists(path + "/" + desktopFileName)) {
             desktopFileFound = true;
             break;

--- a/src/trending/TrendingWindow.cpp
+++ b/src/trending/TrendingWindow.cpp
@@ -23,18 +23,18 @@
 #include "../GitHubClient.h"
 #include "../NewIssueDialog.h"
 
-TrendingWindow::TrendingWindow(GitHubClient *client, QWidget *parent)
+TrendingWindow::TrendingWindow(GitHubClient* client, QWidget* parent)
     : KXmlGuiWindow(parent, Qt::Window), m_client(client) {
     setWindowTitle(tr("Trending Repos & Devs"));
     resize(800, 600);  // make it a bit larger to fit columns
 
-    QWidget *centralWidget = new QWidget(this);
+    QWidget* centralWidget = new QWidget(this);
     setObjectName("TrendingWindow");
     setCentralWidget(centralWidget);
     setupGUI(Default, ":/kgithub-notifyui.rc");
-    QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
+    QVBoxLayout* mainLayout = new QVBoxLayout(centralWidget);
 
-    QHBoxLayout *topLayout = new QHBoxLayout();
+    QHBoxLayout* topLayout = new QHBoxLayout();
 
     modeComboBox = new QComboBox(this);
     modeComboBox->addItem(tr("Repositories"));
@@ -88,20 +88,20 @@ TrendingWindow::TrendingWindow(GitHubClient *client, QWidget *parent)
     mainLayout->addLayout(topLayout);
     mainLayout->addWidget(tableWidget);
 
-    QMenuBar *menuBarWidget = menuBar();
-    QMenu *fileMenu = menuBarWidget->addMenu(tr("&File"));
-    QAction *closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
+    QMenuBar* menuBarWidget = menuBar();
+    QMenu* fileMenu = menuBarWidget->addMenu(tr("&File"));
+    QAction* closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
     closeAction->setShortcut(QKeySequence::Close);
     connect(closeAction, &QAction::triggered, this, &TrendingWindow::close);
     fileMenu->addAction(closeAction);
 
-    QMenu *editMenu = menuBarWidget->addMenu(tr("&Edit"));
-    QAction *copyAction = new QAction(QIcon::fromTheme("edit-copy"), tr("Copy Link"), this);
+    QMenu* editMenu = menuBarWidget->addMenu(tr("&Edit"));
+    QAction* copyAction = new QAction(QIcon::fromTheme("edit-copy"), tr("Copy Link"), this);
     copyAction->setShortcut(QKeySequence::Copy);
     connect(copyAction, &QAction::triggered, this, [this]() {
-        QList<QTableWidgetItem *> items = tableWidget->selectedItems();
+        QList<QTableWidgetItem*> items = tableWidget->selectedItems();
         if (!items.isEmpty()) {
-            QTableWidgetItem *item = items.first();
+            QTableWidgetItem* item = items.first();
             if (item) {
                 QString url = item->data(Qt::UserRole).toString();
                 if (!url.isEmpty()) {
@@ -112,8 +112,8 @@ TrendingWindow::TrendingWindow(GitHubClient *client, QWidget *parent)
     });
     editMenu->addAction(copyAction);
 
-    QMenu *viewMenu = menuBarWidget->addMenu(tr("&View"));
-    QAction *refreshAction = new QAction(QIcon::fromTheme("view-refresh"), tr("Refresh"), this);
+    QMenu* viewMenu = menuBarWidget->addMenu(tr("&View"));
+    QAction* refreshAction = new QAction(QIcon::fromTheme("view-refresh"), tr("Refresh"), this);
     refreshAction->setShortcut(QKeySequence::Refresh);
     connect(refreshAction, &QAction::triggered, this, &TrendingWindow::onRefreshClicked);
     viewMenu->addAction(refreshAction);
@@ -130,19 +130,19 @@ TrendingWindow::TrendingWindow(GitHubClient *client, QWidget *parent)
             &TrendingWindow::onRefreshClicked);
     connect(tableWidget, &QTableWidget::itemActivated, this, &TrendingWindow::onItemActivated);
     connect(tableWidget, &QTableWidget::itemSelectionChanged, this, &TrendingWindow::onItemSelectionChanged);
-    connect(tableWidget, &QTableWidget::customContextMenuRequested, this, [this](const QPoint &pos) {
-        QTableWidgetItem *item = tableWidget->itemAt(pos);
+    connect(tableWidget, &QTableWidget::customContextMenuRequested, this, [this](const QPoint& pos) {
+        QTableWidgetItem* item = tableWidget->itemAt(pos);
         if (!item) return;
 
         QMenu menu(this);
-        QAction *openAction = menu.addAction(tr("Open in Browser"));
-        QAction *copyAction = menu.addAction(tr("Copy Link"));
+        QAction* openAction = menu.addAction(tr("Open in Browser"));
+        QAction* copyAction = menu.addAction(tr("Copy Link"));
         menu.addSeparator();
-        QAction *newIssueAction = menu.addAction(tr("New Issue..."));
+        QAction* newIssueAction = menu.addAction(tr("New Issue..."));
         menu.addSeparator();
-        QAction *viewRawAction = menu.addAction(tr("View Raw JSON"));
+        QAction* viewRawAction = menu.addAction(tr("View Raw JSON"));
 
-        QAction *selectedAction = menu.exec(tableWidget->mapToGlobal(pos));
+        QAction* selectedAction = menu.exec(tableWidget->mapToGlobal(pos));
         if (selectedAction == openAction) {
             onItemActivated(item);
         } else if (selectedAction == copyAction) {
@@ -151,7 +151,7 @@ TrendingWindow::TrendingWindow(GitHubClient *client, QWidget *parent)
         } else if (selectedAction == newIssueAction) {
             QString url = item->data(Qt::UserRole).toString();
             if (m_client) {
-                NewIssueDialog *dialog = new NewIssueDialog(m_client, this);
+                NewIssueDialog* dialog = new NewIssueDialog(m_client, this);
                 dialog->setAttribute(Qt::WA_DeleteOnClose);
                 QString repoName = QUrl(url).path().mid(1);  // removes leading slash
                 dialog->setInitialRepo(repoName);
@@ -161,11 +161,11 @@ TrendingWindow::TrendingWindow(GitHubClient *client, QWidget *parent)
             QString rawJson = item->data(Qt::UserRole + 1).toString();
             // Display raw JSON in a simple widget or dialog
             if (!rawJson.isEmpty()) {
-                QDialog *dialog = new QDialog(this);
+                QDialog* dialog = new QDialog(this);
                 dialog->setWindowTitle(tr("Raw JSON"));
                 dialog->resize(400, 300);
-                QVBoxLayout *layout = new QVBoxLayout(dialog);
-                QTextEdit *textEdit = new QTextEdit(dialog);
+                QVBoxLayout* layout = new QVBoxLayout(dialog);
+                QTextEdit* textEdit = new QTextEdit(dialog);
                 textEdit->setReadOnly(true);
                 textEdit->setPlainText(rawJson);
                 layout->addWidget(textEdit);
@@ -241,7 +241,7 @@ void TrendingWindow::onRefreshClicked() {
     m_client->requestRaw(endpoint);
 }
 
-void TrendingWindow::onRawDataReceived(const QByteArray &data) {
+void TrendingWindow::onRawDataReceived(const QByteArray& data) {
     // Only process if it looks like a search response. We use lastRequestedUrl to match loosely if possible.
     // In our client, requestRaw doesn't pass back the endpoint it requested.
     // So we'll try to parse and check if it's the right format.
@@ -315,33 +315,33 @@ void TrendingWindow::onRawDataReceived(const QByteArray &data) {
             QString stars = QString::number(itemObj["stargazers_count"].toInt());
             QString lang = itemObj["language"].toString();
 
-            QTableWidgetItem *starItem = new QTableWidgetItem("");
+            QTableWidgetItem* starItem = new QTableWidgetItem("");
             starItem->setTextAlignment(Qt::AlignCenter);
             starItem->setData(Qt::UserRole, htmlUrl);
             starItem->setData(Qt::UserRole + 2, name);
             starItem->setFont(font);
 
-            QTableWidgetItem *nameItem = new QTableWidgetItem(name);
+            QTableWidgetItem* nameItem = new QTableWidgetItem(name);
             nameItem->setData(Qt::UserRole, htmlUrl);
             nameItem->setData(Qt::UserRole + 1, rawJson);
             nameItem->setFont(font);
-            QTableWidgetItem *starsItem = new QTableWidgetItem(stars);
+            QTableWidgetItem* starsItem = new QTableWidgetItem(stars);
             starsItem->setData(Qt::UserRole, htmlUrl);
             starsItem->setData(Qt::UserRole + 1, rawJson);
             starsItem->setFont(font);
-            QTableWidgetItem *langItem = new QTableWidgetItem(lang);
+            QTableWidgetItem* langItem = new QTableWidgetItem(lang);
             langItem->setData(Qt::UserRole, htmlUrl);
             langItem->setData(Qt::UserRole + 1, rawJson);
             langItem->setFont(font);
-            QTableWidgetItem *descItem = new QTableWidgetItem(desc);
+            QTableWidgetItem* descItem = new QTableWidgetItem(desc);
             descItem->setData(Qt::UserRole, htmlUrl);
             descItem->setData(Qt::UserRole + 1, rawJson);
             descItem->setFont(font);
 
-            QLabel *linkLabel = new QLabel(QString("<a href='%1'>%1</a>").arg(htmlUrl));
+            QLabel* linkLabel = new QLabel(QString("<a href='%1'>%1</a>").arg(htmlUrl));
             linkLabel->setOpenExternalLinks(true);
             linkLabel->setFont(font);
-            QTableWidgetItem *urlItem = new QTableWidgetItem();  // Empty item to hold the widget's place and data
+            QTableWidgetItem* urlItem = new QTableWidgetItem();  // Empty item to hold the widget's place and data
             urlItem->setData(Qt::UserRole, htmlUrl);
             urlItem->setData(Qt::UserRole + 1, rawJson);
 
@@ -356,22 +356,22 @@ void TrendingWindow::onRawDataReceived(const QByteArray &data) {
             // Fetch starred status
             QUrl url("https://api.github.com/user/starred/" + name);
             QNetworkRequest request = m_client->createAuthenticatedRequest(url);
-            QNetworkReply *reply = m_netManager->get(request);
+            QNetworkReply* reply = m_netManager->get(request);
             reply->setProperty("fullName", name);
 
         } else {
             // Developers
             QString login = itemObj["login"].toString();
 
-            QTableWidgetItem *loginItem = new QTableWidgetItem(login);
+            QTableWidgetItem* loginItem = new QTableWidgetItem(login);
             loginItem->setData(Qt::UserRole, htmlUrl);
             loginItem->setData(Qt::UserRole + 1, rawJson);
             loginItem->setFont(font);
 
-            QLabel *linkLabel = new QLabel(QString("<a href='%1'>%1</a>").arg(htmlUrl));
+            QLabel* linkLabel = new QLabel(QString("<a href='%1'>%1</a>").arg(htmlUrl));
             linkLabel->setOpenExternalLinks(true);
             linkLabel->setFont(font);
-            QTableWidgetItem *urlItem = new QTableWidgetItem();
+            QTableWidgetItem* urlItem = new QTableWidgetItem();
             urlItem->setData(Qt::UserRole, htmlUrl);
             urlItem->setData(Qt::UserRole + 1, rawJson);
 
@@ -398,7 +398,7 @@ void TrendingWindow::onRawDataReceived(const QByteArray &data) {
     tableWidget->resizeRowsToContents();
 }
 
-void TrendingWindow::onItemActivated(QTableWidgetItem *item) {
+void TrendingWindow::onItemActivated(QTableWidgetItem* item) {
     if (!item) return;
     QString url = item->data(Qt::UserRole).toString();
     if (!url.isEmpty()) {
@@ -406,14 +406,14 @@ void TrendingWindow::onItemActivated(QTableWidgetItem *item) {
     }
 }
 
-void TrendingWindow::onRepoStarredCheckFinished(QNetworkReply *reply) {
+void TrendingWindow::onRepoStarredCheckFinished(QNetworkReply* reply) {
     if (!reply) return;
 
     QString fullName = reply->property("fullName").toString();
     if (!fullName.isEmpty() && (reply->error() == QNetworkReply::NoError ||
                                 reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 204)) {
         for (int r = 0; r < tableWidget->rowCount(); ++r) {
-            QTableWidgetItem *item = tableWidget->item(r, 0);
+            QTableWidgetItem* item = tableWidget->item(r, 0);
             if (item && item->data(Qt::UserRole + 2).toString() == fullName) {
                 item->setText("★");
                 break;
@@ -424,23 +424,23 @@ void TrendingWindow::onRepoStarredCheckFinished(QNetworkReply *reply) {
 }
 
 void TrendingWindow::onItemSelectionChanged() {
-    QList<QTableWidgetItem *> selected = tableWidget->selectedItems();
+    QList<QTableWidgetItem*> selected = tableWidget->selectedItems();
     bool changed = false;
-    for (QTableWidgetItem *item : selected) {
+    for (QTableWidgetItem* item : selected) {
         QString url = item->data(Qt::UserRole).toString();
         if (!url.isEmpty() && !m_selectedUrls.contains(url)) {
             m_selectedUrls.insert(url);
             changed = true;
             int row = item->row();
             for (int col = 0; col < tableWidget->columnCount(); ++col) {
-                QTableWidgetItem *colItem = tableWidget->item(row, col);
+                QTableWidgetItem* colItem = tableWidget->item(row, col);
                 if (colItem) {
                     QFont font = colItem->font();
                     font.setBold(false);
                     colItem->setFont(font);
                 }
             }
-            QWidget *w = tableWidget->cellWidget(row, tableWidget->columnCount() - 1);
+            QWidget* w = tableWidget->cellWidget(row, tableWidget->columnCount() - 1);
             if (w) {
                 QFont font = w->font();
                 font.setBold(false);

--- a/src/trending/TrendingWindow.h
+++ b/src/trending/TrendingWindow.h
@@ -19,29 +19,29 @@ class TrendingWindow : public KXmlGuiWindow {
     Q_OBJECT
 
    public:
-    explicit TrendingWindow(GitHubClient *client, QWidget *parent = nullptr);
+    explicit TrendingWindow(GitHubClient* client, QWidget* parent = nullptr);
 
    private slots:
     void onRefreshClicked();
-    void onItemActivated(QTableWidgetItem *item);
+    void onItemActivated(QTableWidgetItem* item);
     void onModeChanged(int index);
-    void onRawDataReceived(const QByteArray &data);
-    void onRepoStarredCheckFinished(QNetworkReply *reply);
+    void onRawDataReceived(const QByteArray& data);
+    void onRepoStarredCheckFinished(QNetworkReply* reply);
     void onItemSelectionChanged();
 
    private:
-    QComboBox *modeComboBox;
-    QComboBox *timeframeComboBox;
-    QComboBox *langComboBox;
-    QComboBox *spokenLangComboBox;
-    QPushButton *refreshButton;
-    QTableWidget *tableWidget;
-    GitHubClient *m_client;
+    QComboBox* modeComboBox;
+    QComboBox* timeframeComboBox;
+    QComboBox* langComboBox;
+    QComboBox* spokenLangComboBox;
+    QPushButton* refreshButton;
+    QTableWidget* tableWidget;
+    GitHubClient* m_client;
 
     // Store the last requested URL to ignore responses from other raw requests
     QString lastRequestedUrl;
     QSet<QString> m_selectedUrls;
-    QNetworkAccessManager *m_netManager;
+    QNetworkAccessManager* m_netManager;
 };
 
 #endif  // TRENDINGWINDOW_H

--- a/tests/MockNetworkReply.h
+++ b/tests/MockNetworkReply.h
@@ -7,7 +7,7 @@
 class MockNetworkReply : public QNetworkReply {
     Q_OBJECT
    public:
-    MockNetworkReply(const QByteArray& data, QObject* parent = nullptr) : QNetworkReply(parent) {
+    explicit MockNetworkReply(const QByteArray& data, QObject* parent = nullptr) : QNetworkReply(parent) {
         setOpenMode(QIODevice::ReadOnly);
         m_buffer.setData(data);
         m_buffer.open(QIODevice::ReadOnly);

--- a/tests/MockNetworkReply.h
+++ b/tests/MockNetworkReply.h
@@ -7,7 +7,7 @@
 class MockNetworkReply : public QNetworkReply {
     Q_OBJECT
    public:
-    MockNetworkReply(const QByteArray &data, QObject *parent = nullptr) : QNetworkReply(parent) {
+    MockNetworkReply(const QByteArray& data, QObject* parent = nullptr) : QNetworkReply(parent) {
         setOpenMode(QIODevice::ReadOnly);
         m_buffer.setData(data);
         m_buffer.open(QIODevice::ReadOnly);
@@ -15,17 +15,17 @@ class MockNetworkReply : public QNetworkReply {
 
     void abort() override {}
 
-    qint64 readData(char *data, qint64 maxlen) override { return m_buffer.read(data, maxlen); }
+    qint64 readData(char* data, qint64 maxlen) override { return m_buffer.read(data, maxlen); }
 
     qint64 bytesAvailable() const override { return m_buffer.bytesAvailable() + QNetworkReply::bytesAvailable(); }
 
-    void setAttribute(QNetworkRequest::Attribute code, const QVariant &value) {
+    void setAttribute(QNetworkRequest::Attribute code, const QVariant& value) {
         QNetworkReply::setAttribute(code, value);
     }
 
-    void setError(NetworkError code, const QString &errorString) { QNetworkReply::setError(code, errorString); }
+    void setError(NetworkError code, const QString& errorString) { QNetworkReply::setError(code, errorString); }
 
-    void setRawHeader(const QByteArray &name, const QByteArray &value) { QNetworkReply::setRawHeader(name, value); }
+    void setRawHeader(const QByteArray& name, const QByteArray& value) { QNetworkReply::setRawHeader(name, value); }
 
    private:
     QBuffer m_buffer;

--- a/tests/TestGitHubClient.cpp
+++ b/tests/TestGitHubClient.cpp
@@ -23,11 +23,11 @@ class TestGitHubClient : public QObject {
             "[{\"id\":\"1\", \"subject\":{\"title\":\"Test\", \"url\":\"http://api.github.com/repos/foo/bar\", "
             "\"type\":\"Issue\"}, \"repository\":{\"full_name\":\"foo/bar\"}, \"updated_at\":\"2023-01-01T00:00:00Z\", "
             "\"unread\":true}]";
-        MockNetworkReply *reply = new MockNetworkReply(json, &client);
+        MockNetworkReply* reply = new MockNetworkReply(json, &client);
         reply->setProperty("type", "notifications");
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
-        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply *, reply));
+        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
 
         QCOMPARE(spy.count(), 1);
         QList<QVariant> args = spy.takeFirst();
@@ -48,14 +48,14 @@ class TestGitHubClient : public QObject {
         QByteArray json =
             "[{\"id\":\"2\", \"subject\":{\"title\":\"Test2\", \"url\":\"url\", \"type\":\"Issue\"}, "
             "\"repository\":{\"full_name\":\"repo\"}, \"updated_at\":\"date\", \"unread\":true}]";
-        MockNetworkReply *reply = new MockNetworkReply(json, &client);
+        MockNetworkReply* reply = new MockNetworkReply(json, &client);
         reply->setProperty("type", "notifications");
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
         reply->setRawHeader("Link",
                             "<https://api.github.com/notifications?page=2>; rel=\"next\", "
                             "<https://api.github.com/notifications?page=5>; rel=\"last\"");
 
-        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply *, reply));
+        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
 
         QCOMPARE(spy.count(), 1);
         QList<QVariant> args = spy.takeFirst();
@@ -74,12 +74,12 @@ class TestGitHubClient : public QObject {
 
         QByteArray json =
             "{\"html_url\":\"http://github.com/foo/bar\", \"user\":{\"login\":\"user\", \"avatar_url\":\"url\"}}";
-        MockNetworkReply *reply = new MockNetworkReply(json, &client);
+        MockNetworkReply* reply = new MockNetworkReply(json, &client);
         reply->setProperty("type", "details");
         reply->setProperty("notificationId", "123");
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
-        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply *, reply));
+        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
 
         QCOMPARE(spy.count(), 1);
         QList<QVariant> args = spy.takeFirst();
@@ -91,13 +91,13 @@ class TestGitHubClient : public QObject {
         GitHubClient client;
         QSignalSpy spy(&client, &GitHubClient::detailsError);
 
-        MockNetworkReply *reply = new MockNetworkReply("", &client);
+        MockNetworkReply* reply = new MockNetworkReply("", &client);
         reply->setProperty("type", "details");
         reply->setProperty("notificationId", "123");
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 404);
         reply->setError(QNetworkReply::ContentNotFoundError, "Not Found");
 
-        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply *, reply));
+        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
 
         QCOMPARE(spy.count(), 1);
         QList<QVariant> args = spy.takeFirst();
@@ -110,11 +110,11 @@ class TestGitHubClient : public QObject {
         QSignalSpy spy(&client, &GitHubClient::tokenVerified);
 
         QByteArray json = "{\"login\":\"user\"}";
-        MockNetworkReply *reply = new MockNetworkReply(json, &client);
+        MockNetworkReply* reply = new MockNetworkReply(json, &client);
         reply->setProperty("type", "verification");
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
-        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply *, reply));
+        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
 
         QCOMPARE(spy.count(), 1);
         QList<QVariant> args = spy.takeFirst();
@@ -158,11 +158,11 @@ class TestGitHubClient : public QObject {
         array.append(n3);
         QJsonDocument doc(array);
 
-        MockNetworkReply *reply = new MockNetworkReply(doc.toJson(), &client);
+        MockNetworkReply* reply = new MockNetworkReply(doc.toJson(), &client);
         reply->setProperty("type", "notifications");
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
-        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply *, reply));
+        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
 
         QCOMPARE(spy.count(), 1);
         QList<Notification> notifications = spy.takeFirst().at(0).value<QList<Notification>>();
@@ -253,11 +253,11 @@ class TestGitHubClient : public QObject {
         array.append(n4);
         QJsonDocument doc(array);
 
-        MockNetworkReply *reply = new MockNetworkReply(doc.toJson(), &client);
+        MockNetworkReply* reply = new MockNetworkReply(doc.toJson(), &client);
         reply->setProperty("type", "notifications");
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
-        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply *, reply));
+        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
 
         QCOMPARE(spy.count(), 1);
         QList<Notification> notifications = spy.takeFirst().at(0).value<QList<Notification>>();


### PR DESCRIPTION
Formatted all C++ source and header files in `src` and `tests` directories using `clang-format -i` to fix code styling violations.

---
*PR created automatically by Jules for task [6704991088095706282](https://jules.google.com/task/6704991088095706282) started by @arran4*