### PR TITLE
test: Add .gitleaksignore to suppress false positive test tokens

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,10 @@
+# Ignore false positive test tokens in tests/TestMain.cpp
+f7d24bf74cc6f03c0bab999099cb9f4102f32e7d:tests/TestMain.cpp:generic-api-key:29
+59b70a970ecb32809eab4a5843d01ca8d65bb0dd:tests/TestMain.cpp:generic-api-key:29
+9646d0b88c84edc7133f04c93031adc024343e9d:tests/TestMain.cpp:generic-api-key:29
+be0a1475420e98b8176c96877739a9e49c698c33:tests/TestMain.cpp:generic-api-key:29
+958620fb03db72fd3157505fc244ab82ca980532:tests/TestMain.cpp:generic-api-key:29
+3e27755c5b2f5fff16f729f81f03ca488aae02e7:tests/TestMain.cpp:generic-api-key:29
+e26efa595f02a32e66946fda7996acb72afb7609:tests/TestMain.cpp:generic-api-key:29
+4622a7f84d0e5a32ef018c23bbe5066a018da589:tests/TestMain.cpp:generic-api-key:29
+00a8bb91932a0534376f464cb4d780c3c9454d95:tests/TestMain.cpp:generic-api-key:29


### PR DESCRIPTION
Adds `.gitleaksignore` file to fix CI failures.

---
*PR created automatically by Jules for task [18299184812213806782](https://jules.google.com/task/18299184812213806782) started by @arran4*