### PR TITLE
feat: Enable smooth scrolling on all list and table views

### DIFF
--- a/src/ActionWindow.cpp
+++ b/src/ActionWindow.cpp
@@ -32,6 +32,7 @@ void ActionWindow::setupUi() {
     layout->addWidget(m_statusLabel);
 
     m_jobsTable = new QTableWidget();
+    m_jobsTable->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     m_jobsTable->setColumnCount(4);
     m_jobsTable->setHorizontalHeaderLabels({tr("Job Name"), tr("Status"), tr("Conclusion"), tr("Started At")});
     m_jobsTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);

--- a/src/NotificationListWidget.cpp
+++ b/src/NotificationListWidget.cpp
@@ -42,6 +42,7 @@ NotificationListWidget::NotificationListWidget(QWidget* parent)
     layout->setContentsMargins(0, 0, 0, 0);
 
     listWidget = new QListWidget(this);
+    listWidget->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     listWidget->setSelectionMode(QAbstractItemView::ExtendedSelection);
     listWidget->setAlternatingRowColors(true);
 

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -55,6 +55,7 @@ void PullRequestWindow::setupUi() {
     m_commitsTab = new QWidget();
     m_commitsLayout = new QVBoxLayout(m_commitsTab);
     m_commitsTable = new QTableWidget();
+    m_commitsTable->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     m_commitsTable->setColumnCount(4);
     m_commitsTable->setHorizontalHeaderLabels({tr("SHA"), tr("Author"), tr("Message"), tr("Date")});
     m_commitsTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
@@ -67,6 +68,7 @@ void PullRequestWindow::setupUi() {
     m_filesTab = new QWidget();
     m_filesLayout = new QVBoxLayout(m_filesTab);
     m_filesTable = new QTableWidget();
+    m_filesTable->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     m_filesTable->setColumnCount(4);
     m_filesTable->setHorizontalHeaderLabels({tr("Filename"), tr("Additions"), tr("Deletions"), tr("Changes")});
     m_filesTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);

--- a/src/RepoListWindow.cpp
+++ b/src/RepoListWindow.cpp
@@ -52,6 +52,7 @@ void RepoListWindow::setupUI() {
 
     // Table
     m_table = new QTableWidget(this);
+    m_table->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     m_table->setColumnCount(8);
     m_table->setHorizontalHeaderLabels({tr("Name"), tr("Owner"), tr("Visibility"), tr("Stars"), tr("Forks"),
                                         tr("Open Issues"), tr("Updated"), tr("URL")});

--- a/src/RulesDialog.cpp
+++ b/src/RulesDialog.cpp
@@ -20,6 +20,7 @@ RulesDialog::RulesDialog(QWidget* parent, const QString& preFilterRepo, const QS
     QVBoxLayout* mainLayout = new QVBoxLayout(this);
 
     rulesTable = new QTableWidget(0, 2, this);
+    rulesTable->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     rulesTable->setHorizontalHeaderLabels({tr("Rule Matcher"), tr("Action")});
     rulesTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
     rulesTable->setSelectionBehavior(QAbstractItemView::SelectRows);

--- a/src/WorkItemWindow.cpp
+++ b/src/WorkItemWindow.cpp
@@ -43,6 +43,7 @@ void WorkItemWindow::setupUi() {
 
     // Table
     m_table = new QTableWidget(this);
+    m_table->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     m_table->setColumnCount(5);
     if (m_endpointType == EndpointIssues) {
         m_table->setHorizontalHeaderLabels(

--- a/src/trending/TrendingWindow.cpp
+++ b/src/trending/TrendingWindow.cpp
@@ -78,6 +78,7 @@ TrendingWindow::TrendingWindow(GitHubClient* client, QWidget* parent)
     topLayout->addWidget(refreshButton);
 
     tableWidget = new QTableWidget(this);
+    tableWidget->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     tableWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
     tableWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
     tableWidget->setWordWrap(true);


### PR DESCRIPTION
Sets vertical scroll mode to `ScrollPerPixel` for `QListWidget` and `QTableWidget` across the application to provide a smoother user experience, rather than the default item-by-item scrolling which is jarring on large notification items.

---
*PR created automatically by Jules for task [2217780479254820833](https://jules.google.com/task/2217780479254820833) started by @arran4*