### PR TITLE
Fix clang-format lint error in MainWindow.cpp

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -520,7 +520,7 @@ void MainWindow::createTrayIcon() {
 
 void MainWindow::updateTrayMenu() {
     if (!trayIcon) return;
-    QMenu *newTrayIconMenu = new QMenu(this);
+    QMenu* newTrayIconMenu = new QMenu(this);
 
     QAction* openAppAction =
         new QAction(themedIcon({QStringLiteral("kgithub-notify")}), tr("Open Kgithub-notify"), newTrayIconMenu);


### PR DESCRIPTION
Fixed a clang-format lint issue by correcting pointer declaration formatting (`QMenu *newTrayIconMenu` -> `QMenu* newTrayIconMenu`) in `src/MainWindow.cpp`. Verified the fix using the `clang-format --dry-run` and running all tests inside the Docker container.

---
*PR created automatically by Jules for task [201125854952035741](https://jules.google.com/task/201125854952035741) started by @arran4*