### PR TITLE
ci: fix flatpak-builder system deploy polkit errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,9 @@ jobs:
       - name: Install xvfb and flatpak-builder
         run: |
           sudo apt-get update && sudo apt-get install -y xvfb flatpak-builder flatpak
+          sudo mkdir -p /etc/polkit-1/rules.d/
+          echo 'polkit.addRule(function(action, subject) { if (action.id.indexOf("org.freedesktop.Flatpak.") == 0 && subject.isInGroup("sudo")) { return polkit.Result.YES; } });' | sudo tee /etc/polkit-1/rules.d/99-flatpak.rules
+          sudo systemctl restart polkit || true
           sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       - name: Build Flatpak
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6


### PR DESCRIPTION
- Added a polkit rule creation step to the `flatpak-build` CI job.
- The rule permits `org.freedesktop.Flatpak.*` actions for users in the `sudo` group.
- This bypasses `Deploy not allowed for user` failures occurring in newer Ubuntu runner environments (e.g., Ubuntu 24.04).

---
*PR created automatically by Jules for task [15752175129696742489](https://jules.google.com/task/15752175129696742489) started by @arran4*