### PR TITLE
ci: fix flatpak build polkit permission errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y xvfb flatpak-builder flatpak
           sudo mkdir -p /etc/polkit-1/rules.d/
-          echo 'polkit.addRule(function(action, subject) { if (action.id.indexOf("org.freedesktop.Flatpak.") == 0 && subject.isInGroup("sudo")) { return polkit.Result.YES; } });' | sudo tee /etc/polkit-1/rules.d/99-flatpak.rules
+          echo 'polkit.addRule(function(action, subject) { if (action.id.indexOf("org.freedesktop.Flatpak.") === 0) { return polkit.Result.YES; } });' | sudo tee /etc/polkit-1/rules.d/99-flatpak.rules
           sudo systemctl restart polkit || true
           sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       - name: Build Flatpak


### PR DESCRIPTION
Fixes the persistent Flatpak build failure (`Flatpak system operation GetRevokefsFd not allowed for user`) in GitHub Actions. Removing the `isInGroup("sudo")` check from the injected Polkit rule ensures the `runner` user unconditionally receives permission to perform system-level Flatpak deployments during the CI job.

---
*PR created automatically by Jules for task [11248653223615032861](https://jules.google.com/task/11248653223615032861) started by @arran4*