### PR TITLE
Fix syntax error in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,3 +565,4 @@ jobs:
               --body "Automated update of kgithub-notify ebuild for version ${VERSION}." \
               --base main \
               --head $BRANCH_NAME
+          fi


### PR DESCRIPTION
Added the missing `fi` to close the `if` block at the end of the `update-ebuild` job in `.github/workflows/ci.yml` that was causing the `unexpected end of file` error.

---
*PR created automatically by Jules for task [14714155599113738008](https://jules.google.com/task/14714155599113738008) started by @arran4*