### PR TITLE
Render PR comments in Markdown

### DIFF
--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -202,7 +202,7 @@ void PullRequestWindow::onReviewCommentsReply(QNetworkReply* reply) {
             QString diffHunk = obj["diff_hunk"].toString();
 
             QString fullBody =
-                tr("<b>Review comment on %1:</b><br><pre>%2</pre><br>%3").arg(path, diffHunk.toHtmlEscaped(), body);
+                tr("**Review comment on %1:**\n\n```diff\n%2\n```\n\n%3").arg(path, diffHunk, body);
             addCommentToUI(author, fullBody, createdAt);
         }
     }
@@ -284,7 +284,8 @@ void PullRequestWindow::addCommentToUI(const QString& author, const QString& bod
     QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
     QString formattedDate = QLocale().toString(dt, QLocale::ShortFormat);
 
-    QLabel* label = new QLabel(tr("<b>%1</b> on %2<br>%3<hr>").arg(author, formattedDate, body));
+    QLabel* label = new QLabel(tr("**%1** on %2\n\n%3\n\n---").arg(author, formattedDate, body));
+    label->setTextFormat(Qt::MarkdownText);
     label->setWordWrap(true);
     label->setTextInteractionFlags(Qt::TextBrowserInteraction);
     label->setOpenExternalLinks(true);

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -283,7 +283,8 @@ void PullRequestWindow::addCommentToUI(const QString& author, const QString& bod
     QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
     QString formattedDate = QLocale().toString(dt, QLocale::ShortFormat);
 
-    QLabel* label = new QLabel(tr("**%1** on %2\n\n%3\n\n---").arg(author, formattedDate, body));
+    QLabel* label = new QLabel(tr("**%1** on %2").arg(author, formattedDate) + QStringLiteral("\n\n") + body +
+                               QStringLiteral("\n\n---"));
     label->setTextFormat(Qt::MarkdownText);
     label->setWordWrap(true);
     label->setTextInteractionFlags(Qt::TextBrowserInteraction);

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -201,8 +201,7 @@ void PullRequestWindow::onReviewCommentsReply(QNetworkReply* reply) {
             QString path = obj["path"].toString();
             QString diffHunk = obj["diff_hunk"].toString();
 
-            QString fullBody =
-                tr("**Review comment on %1:**\n\n```diff\n%2\n```\n\n%3").arg(path, diffHunk, body);
+            QString fullBody = tr("**Review comment on %1:**\n\n```diff\n%2\n```\n\n%3").arg(path, diffHunk, body);
             addCommentToUI(author, fullBody, createdAt);
         }
     }


### PR DESCRIPTION
Render PR comments in Markdown

### Description
This pull request modifies `PullRequestWindow` to format GitHub conversation and review comments using Markdown instead of raw text or inline HTML.

- Updated `addCommentToUI` string template to use Markdown semantics (`**author** on date \n\nbody\n\n---`).
- Updated `onReviewCommentsReply` to enclose `diffHunk` payloads inside Markdown code blocks (````diff`), and removed the `.toHtmlEscaped()` call.
- Set the `QLabel` format to `Qt::MarkdownText` inside `addCommentToUI`.

### Testing
Compiled the binaries and ran `ctest` inside the provided `kgithub-notify-builder` Docker container to ensure no runtime or compilation regressions were introduced.

---
*PR created automatically by Jules for task [17728154939481458069](https://jules.google.com/task/17728154939481458069) started by @arran4*