### PR TITLE
Fix Pull Request menus and add View Raw JSON

### DIFF
--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -1,15 +1,15 @@
 #include "PullRequestWindow.h"
 
+#include <KActionCollection>
+#include <KStandardAction>
 #include <QDateTime>
+#include <QDesktopServices>
 #include <QHeaderView>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMessageBox>
-#include <KStandardAction>
-#include <KActionCollection>
 #include <QTextEdit>
-#include <QDesktopServices>
 
 PullRequestWindow::PullRequestWindow(const Notification& n, GitHubClient* client, QWidget* parent)
     : KXmlGuiWindow(parent, Qt::Window),
@@ -324,7 +324,8 @@ void PullRequestWindow::setupMenus() {
 
     // Open in browser mapping for the tools menu since it shares rc file
     QAction* openUrlAction = new QAction(QIcon::fromTheme("internet-web-browser"), tr("Open PR in Browser"), this);
-    connect(openUrlAction, &QAction::triggered, this, [this]() { QDesktopServices::openUrl(QUrl(m_notification.url)); });
+    connect(openUrlAction, &QAction::triggered, this,
+            [this]() { QDesktopServices::openUrl(QUrl(m_notification.url)); });
     actionCollection()->addAction(QStringLiteral("open_browser"), openUrlAction);
 }
 

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -4,6 +4,7 @@
 #include <KStandardAction>
 #include <QDateTime>
 #include <QDesktopServices>
+#include <QFontDatabase>
 #include <QHeaderView>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -113,6 +114,9 @@ void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
         m_rawJsonStr = QString::fromUtf8(doc.toJson(QJsonDocument::Indented));
+        if (QAction* action = actionCollection()->action(QStringLiteral("view_raw_json"))) {
+            action->setEnabled(true);
+        }
         QJsonObject obj = doc.object();
 
         m_commentsUrl = obj["comments_url"].toString();
@@ -319,13 +323,14 @@ void PullRequestWindow::onCommentButtonClicked() {
 void PullRequestWindow::setupMenus() {
     KStandardAction::close(this, &PullRequestWindow::close, actionCollection());
     QAction* viewRawJsonAction = new QAction(QIcon::fromTheme("text-x-generic"), tr("View Raw JSON"), this);
+    viewRawJsonAction->setEnabled(false);
     connect(viewRawJsonAction, &QAction::triggered, this, &PullRequestWindow::onViewRawJson);
     actionCollection()->addAction(QStringLiteral("view_raw_json"), viewRawJsonAction);
 
     // Open in browser mapping for the tools menu since it shares rc file
     QAction* openUrlAction = new QAction(QIcon::fromTheme("internet-web-browser"), tr("Open PR in Browser"), this);
     connect(openUrlAction, &QAction::triggered, this,
-            [this]() { QDesktopServices::openUrl(QUrl(m_notification.url)); });
+            [this]() { QDesktopServices::openUrl(QUrl(GitHubClient::apiToHtmlUrl(m_notification.url, m_notification.id))); });
     actionCollection()->addAction(QStringLiteral("open_browser"), openUrlAction);
 }
 
@@ -336,6 +341,7 @@ void PullRequestWindow::onViewRawJson() {
 
     QVBoxLayout* layout = new QVBoxLayout(dialog);
     QTextEdit* textEdit = new QTextEdit(dialog);
+    textEdit->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
     textEdit->setReadOnly(true);
     textEdit->setPlainText(m_rawJsonStr);
     layout->addWidget(textEdit);

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -6,6 +6,10 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMessageBox>
+#include <KStandardAction>
+#include <KActionCollection>
+#include <QTextEdit>
+#include <QDesktopServices>
 
 PullRequestWindow::PullRequestWindow(const Notification& n, GitHubClient* client, QWidget* parent)
     : KXmlGuiWindow(parent, Qt::Window),
@@ -24,6 +28,7 @@ void PullRequestWindow::setupUi() {
     m_tabWidget = new QTabWidget(this);
     setObjectName("PullRequestWindow");
     setCentralWidget(m_tabWidget);
+    setupMenus();
     setupGUI(Default, ":/kgithub-notifyui.rc");
 
     // 1. Conversation Tab
@@ -107,6 +112,7 @@ void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
+        m_rawJsonStr = QString::fromUtf8(doc.toJson(QJsonDocument::Indented));
         QJsonObject obj = doc.object();
 
         m_commentsUrl = obj["comments_url"].toString();
@@ -308,6 +314,33 @@ void PullRequestWindow::onCommentButtonClicked() {
 
     QNetworkReply* reply = m_manager->post(request, data);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onPostCommentReply(reply); });
+}
+
+void PullRequestWindow::setupMenus() {
+    KStandardAction::close(this, &PullRequestWindow::close, actionCollection());
+    QAction* viewRawJsonAction = new QAction(QIcon::fromTheme("text-x-generic"), tr("View Raw JSON"), this);
+    connect(viewRawJsonAction, &QAction::triggered, this, &PullRequestWindow::onViewRawJson);
+    actionCollection()->addAction(QStringLiteral("view_raw_json"), viewRawJsonAction);
+
+    // Open in browser mapping for the tools menu since it shares rc file
+    QAction* openUrlAction = new QAction(QIcon::fromTheme("internet-web-browser"), tr("Open PR in Browser"), this);
+    connect(openUrlAction, &QAction::triggered, this, [this]() { QDesktopServices::openUrl(QUrl(m_notification.url)); });
+    actionCollection()->addAction(QStringLiteral("open_browser"), openUrlAction);
+}
+
+void PullRequestWindow::onViewRawJson() {
+    QDialog* dialog = new QDialog(this);
+    dialog->setWindowTitle(tr("Raw JSON"));
+    dialog->resize(600, 400);
+
+    QVBoxLayout* layout = new QVBoxLayout(dialog);
+    QTextEdit* textEdit = new QTextEdit(dialog);
+    textEdit->setReadOnly(true);
+    textEdit->setPlainText(m_rawJsonStr);
+    layout->addWidget(textEdit);
+
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->show();
 }
 
 void PullRequestWindow::onPostCommentReply(QNetworkReply* reply) {

--- a/src/PullRequestWindow.h
+++ b/src/PullRequestWindow.h
@@ -42,6 +42,7 @@ class PullRequestWindow : public KXmlGuiWindow {
 
     void onCommentButtonClicked();
     void onPostCommentReply(QNetworkReply* reply);
+    void onViewRawJson();
 
    private:
     Notification m_notification;
@@ -83,6 +84,8 @@ class PullRequestWindow : public KXmlGuiWindow {
 
     void setupUi();
     void addCommentToUI(const QString& author, const QString& body, const QString& createdAt);
+    void setupMenus();
+    QString m_rawJsonStr;
 };
 
 #endif  // PULLREQUESTWINDOW_H

--- a/src/kgithub-notifyui.rc
+++ b/src/kgithub-notifyui.rc
@@ -18,6 +18,7 @@
         </Menu>
         <Menu name="view">
             <text>&amp;View</text>
+            <Action name="view_raw_json"/>
             <Action name="view_redisplay"/>
         </Menu>
         <Menu name="settings">
@@ -30,6 +31,7 @@
             <Action name="debug"/>
             <Action name="new_issue"/>
             <Action name="repo_list"/>
+            <Action name="open_browser"/>
             <Separator/>
             <Action name="issues_menu"/>
             <Action name="prs_menu"/>


### PR DESCRIPTION
Fixes the issue where 'File' and 'Tools' menus were empty in the 'Pull request' view window, and implements a feature to view the formatted raw JSON API payload for the PR.

---
*PR created automatically by Jules for task [17353700785937456630](https://jules.google.com/task/17353700785937456630) started by @arran4*