### PR TITLE
feat: allow opening diffs by double-clicking files in PR window

### DIFF
--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -292,7 +292,12 @@ void PullRequestWindow::onFileDoubleClicked(int row, int column) {
 
     QString blobUrl = item->data(Qt::UserRole).toString();
     if (!blobUrl.isEmpty()) {
-        QDesktopServices::openUrl(QUrl(blobUrl));
+        QUrl url(blobUrl);
+        if (url.scheme() == "http" || url.scheme() == "https") {
+            QDesktopServices::openUrl(url);
+        } else {
+            QMessageBox::warning(this, tr("Security Warning"), tr("Blocked attempt to open an unsafe URL scheme."));
+        }
     }
 }
 

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -1,9 +1,9 @@
 #include "PullRequestWindow.h"
 
 #include <QDateTime>
+#include <QDesktopServices>
 #include <QHeaderView>
 #include <QJsonArray>
-#include <QDesktopServices>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMessageBox>

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -293,12 +293,12 @@ void PullRequestWindow::onFileDoubleClicked(int row, int column) {
     QString blobUrl = item->data(Qt::UserRole).toString();
     if (!blobUrl.isEmpty()) {
         QUrl url(blobUrl);
-        if (url.scheme() == "http" || url.scheme() == "https") {
+        if (url.isValid() && (url.scheme() == "http" || url.scheme() == "https")) {
             if (!QDesktopServices::openUrl(url)) {
                 QMessageBox::warning(this, tr("Error"), tr("Failed to open the URL in your web browser."));
             }
         } else {
-            QMessageBox::warning(this, tr("Security Warning"), tr("Blocked attempt to open an unsafe URL scheme."));
+            QMessageBox::warning(this, tr("Security Warning"), tr("Blocked attempt to open an unsafe or invalid URL."));
         }
     }
 }

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -3,9 +3,11 @@
 #include <QDateTime>
 #include <QHeaderView>
 #include <QJsonArray>
+#include <QDesktopServices>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMessageBox>
+#include <QUrl>
 
 PullRequestWindow::PullRequestWindow(const Notification& n, GitHubClient* client, QWidget* parent)
     : KXmlGuiWindow(parent, Qt::Window),
@@ -75,6 +77,7 @@ void PullRequestWindow::setupUi() {
     m_filesTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
     m_filesTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_filesLayout->addWidget(m_filesTable);
+    connect(m_filesTable, &QTableWidget::cellDoubleClicked, this, &PullRequestWindow::onFileDoubleClicked);
     m_tabWidget->addTab(m_filesTab, tr("Changed Files"));
 
     // 4. Metadata Tab
@@ -261,9 +264,12 @@ void PullRequestWindow::onFilesReply(QNetworkReply* reply) {
             int additions = obj["additions"].toInt();
             int deletions = obj["deletions"].toInt();
             int changes = obj["changes"].toInt();
+            QString blobUrl = obj["blob_url"].toString();
 
             m_filesTable->insertRow(i);
-            m_filesTable->setItem(i, 0, new QTableWidgetItem(filename));
+            QTableWidgetItem* fileItem = new QTableWidgetItem(filename);
+            fileItem->setData(Qt::UserRole, blobUrl);
+            m_filesTable->setItem(i, 0, fileItem);
 
             QTableWidgetItem* addItem = new QTableWidgetItem(QString::number(additions));
             addItem->setForeground(QBrush(Qt::darkGreen));
@@ -277,6 +283,17 @@ void PullRequestWindow::onFilesReply(QNetworkReply* reply) {
         }
     }
     reply->deleteLater();
+}
+
+void PullRequestWindow::onFileDoubleClicked(int row, int column) {
+    Q_UNUSED(column);
+    QTableWidgetItem* item = m_filesTable->item(row, 0);
+    if (!item) return;
+
+    QString blobUrl = item->data(Qt::UserRole).toString();
+    if (!blobUrl.isEmpty()) {
+        QDesktopServices::openUrl(QUrl(blobUrl));
+    }
 }
 
 void PullRequestWindow::addCommentToUI(const QString& author, const QString& body, const QString& createdAt) {

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -294,7 +294,9 @@ void PullRequestWindow::onFileDoubleClicked(int row, int column) {
     if (!blobUrl.isEmpty()) {
         QUrl url(blobUrl);
         if (url.scheme() == "http" || url.scheme() == "https") {
-            QDesktopServices::openUrl(url);
+            if (!QDesktopServices::openUrl(url)) {
+                QMessageBox::warning(this, tr("Error"), tr("Failed to open the URL in your web browser."));
+            }
         } else {
             QMessageBox::warning(this, tr("Security Warning"), tr("Blocked attempt to open an unsafe URL scheme."));
         }

--- a/src/PullRequestWindow.h
+++ b/src/PullRequestWindow.h
@@ -40,6 +40,8 @@ class PullRequestWindow : public KXmlGuiWindow {
     void fetchFiles();
     void onFilesReply(QNetworkReply* reply);
 
+    void onFileDoubleClicked(int row, int column);
+
     void onCommentButtonClicked();
     void onPostCommentReply(QNetworkReply* reply);
 


### PR DESCRIPTION
This PR introduces the ability for users to double-click an item in the "Changed Files" table within the Pull Request window, seamlessly opening the associated file blob/diff using their default web browser.

**Changes:**
- Added `onFileDoubleClicked` slot to `PullRequestWindow.h` / `cpp`.
- Stored the `blob_url` parsed from the GitHub PR `/files` API payload inside the filename `QTableWidgetItem`'s `Qt::UserRole` data.
- Connected the `QTableWidget`'s `cellDoubleClicked` signal to the new slot.
- Invoked `QDesktopServices::openUrl` with the `blob_url` when the user double clicks on a row in the changed files tab.

---
*PR created automatically by Jules for task [15723362907971920323](https://jules.google.com/task/15723362907971920323) started by @arran4*