### PR TITLE
Show timeline events in PR conversation tab

### DIFF
--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -218,14 +218,14 @@ void PullRequestWindow::onTimelineReply(QNetworkReply* reply) {
                     QString actor = obj["actor"].toObject()["login"].toString();
                     QString requested = obj["requested_reviewer"].toObject()["login"].toString();
                     if (requested.isEmpty()) {
-                         requested = obj["requested_team"].toObject()["name"].toString();
+                        requested = obj["requested_team"].toObject()["name"].toString();
                     }
                     text = tr("<i>%1 requested a review from %2</i>").arg(actor, requested);
                 } else if (event == "review_request_removed") {
                     QString actor = obj["actor"].toObject()["login"].toString();
                     QString requested = obj["requested_reviewer"].toObject()["login"].toString();
                     if (requested.isEmpty()) {
-                         requested = obj["requested_team"].toObject()["name"].toString();
+                        requested = obj["requested_team"].toObject()["name"].toString();
                     }
                     text = tr("<i>%1 removed the request for review from %2</i>").arg(actor, requested);
                 } else if (event == "reviewed") {

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -114,7 +114,9 @@ void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
         m_commitsUrl = obj["commits_url"].toString();
 
         // Convert issues url to get issue comments url for PR
-        m_issueCommentsUrl = obj["issue_url"].toString() + "/comments";
+        QString issueUrl = obj["issue_url"].toString();
+        m_issueCommentsUrl = issueUrl + "/comments";
+        m_timelineUrl = issueUrl + "/timeline";
 
         // Add the PR body as the first comment
         QString author = obj["user"].toObject()["login"].toString();
@@ -144,7 +146,7 @@ void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
             m_milestoneLabel->setText(tr("<b>Milestone:</b> None"));
         }
 
-        fetchComments();
+        fetchTimeline();
         fetchReviewComments();
         fetchCommits();
         fetchFiles();
@@ -154,15 +156,15 @@ void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
     reply->deleteLater();
 }
 
-void PullRequestWindow::fetchComments() {
-    if (m_issueCommentsUrl.isEmpty()) return;
-    QUrl url(m_issueCommentsUrl);
+void PullRequestWindow::fetchTimeline() {
+    if (m_timelineUrl.isEmpty()) return;
+    QUrl url(m_timelineUrl);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
     QNetworkReply* reply = m_manager->get(request);
-    connect(reply, &QNetworkReply::finished, this, [this, reply]() { onCommentsReply(reply); });
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() { onTimelineReply(reply); });
 }
 
-void PullRequestWindow::onCommentsReply(QNetworkReply* reply) {
+void PullRequestWindow::onTimelineReply(QNetworkReply* reply) {
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -170,10 +172,89 @@ void PullRequestWindow::onCommentsReply(QNetworkReply* reply) {
 
         for (const QJsonValue& val : array) {
             QJsonObject obj = val.toObject();
-            QString author = obj["user"].toObject()["login"].toString();
-            QString body = obj["body"].toString();
-            QString createdAt = obj["created_at"].toString();
-            addCommentToUI(author, body, createdAt);
+            QString event = obj["event"].toString();
+
+            if (event == "commented") {
+                QString author = obj["user"].toObject()["login"].toString();
+                QString body = obj["body"].toString();
+                QString createdAt = obj["created_at"].toString();
+                addCommentToUI(author, body, createdAt);
+            } else {
+                QString createdAt = obj["created_at"].toString();
+                QString text;
+
+                if (event == "committed") {
+                    QString sha = obj["sha"].toString().left(7);
+                    QString message = obj["message"].toString().section('\n', 0, 0);
+                    QString author = obj["author"].toObject()["name"].toString();
+                    text = tr("<i>%1 committed %2: %3</i>").arg(author, sha, message);
+                } else if (event == "assigned") {
+                    QString actor = obj["actor"].toObject()["login"].toString();
+                    QString assignee = obj["assignee"].toObject()["login"].toString();
+                    text = tr("<i>%1 assigned %2</i>").arg(actor, assignee);
+                } else if (event == "unassigned") {
+                    QString actor = obj["actor"].toObject()["login"].toString();
+                    QString assignee = obj["assignee"].toObject()["login"].toString();
+                    text = tr("<i>%1 unassigned %2</i>").arg(actor, assignee);
+                } else if (event == "labeled") {
+                    QString actor = obj["actor"].toObject()["login"].toString();
+                    QString label = obj["label"].toObject()["name"].toString();
+                    text = tr("<i>%1 added the %2 label</i>").arg(actor, label);
+                } else if (event == "unlabeled") {
+                    QString actor = obj["actor"].toObject()["login"].toString();
+                    QString label = obj["label"].toObject()["name"].toString();
+                    text = tr("<i>%1 removed the %2 label</i>").arg(actor, label);
+                } else if (event == "closed") {
+                    QString actor = obj["actor"].toObject()["login"].toString();
+                    text = tr("<i>%1 closed this</i>").arg(actor);
+                } else if (event == "reopened") {
+                    QString actor = obj["actor"].toObject()["login"].toString();
+                    text = tr("<i>%1 reopened this</i>").arg(actor);
+                } else if (event == "merged") {
+                    QString actor = obj["actor"].toObject()["login"].toString();
+                    QString commitId = obj["commit_id"].toString().left(7);
+                    text = tr("<i>%1 merged commit %2</i>").arg(actor, commitId);
+                } else if (event == "review_requested") {
+                    QString actor = obj["actor"].toObject()["login"].toString();
+                    QString requested = obj["requested_reviewer"].toObject()["login"].toString();
+                    if (requested.isEmpty()) {
+                         requested = obj["requested_team"].toObject()["name"].toString();
+                    }
+                    text = tr("<i>%1 requested a review from %2</i>").arg(actor, requested);
+                } else if (event == "review_request_removed") {
+                    QString actor = obj["actor"].toObject()["login"].toString();
+                    QString requested = obj["requested_reviewer"].toObject()["login"].toString();
+                    if (requested.isEmpty()) {
+                         requested = obj["requested_team"].toObject()["name"].toString();
+                    }
+                    text = tr("<i>%1 removed the request for review from %2</i>").arg(actor, requested);
+                } else if (event == "reviewed") {
+                    QString actor = obj["user"].toObject()["login"].toString();
+                    QString state = obj["state"].toString();
+                    text = tr("<i>%1 reviewed this (%2)</i>").arg(actor, state);
+                } else if (event == "head_ref_force_pushed") {
+                    QString actor = obj["actor"].toObject()["login"].toString();
+                    text = tr("<i>%1 force-pushed the branch</i>").arg(actor);
+                } else {
+                    QString actor = obj["actor"].toObject()["login"].toString();
+                    if (actor.isEmpty()) {
+                        actor = obj["user"].toObject()["login"].toString();
+                    }
+                    if (actor.isEmpty()) {
+                        text = tr("<i>Event: %1</i>").arg(event);
+                    } else {
+                        text = tr("<i>%1: %2</i>").arg(actor, event);
+                    }
+                }
+
+                if (!text.isEmpty()) {
+                    QLabel* label = new QLabel(text);
+                    label->setTextFormat(Qt::RichText);
+                    label->setWordWrap(true);
+                    label->setStyleSheet("color: gray;");
+                    m_commentsContainerLayout->addWidget(label);
+                }
+            }
         }
     }
     reply->deleteLater();

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -248,6 +248,11 @@ void PullRequestWindow::onTimelineReply(QNetworkReply* reply) {
                 }
 
                 if (!text.isEmpty()) {
+                    if (!createdAt.isEmpty()) {
+                        QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
+                        QString formattedDate = QLocale().toString(dt, QLocale::ShortFormat);
+                        text += tr(" on %1").arg(formattedDate);
+                    }
                     QLabel* label = new QLabel(text);
                     label->setTextFormat(Qt::RichText);
                     label->setWordWrap(true);
@@ -256,6 +261,8 @@ void PullRequestWindow::onTimelineReply(QNetworkReply* reply) {
                 }
             }
         }
+    } else {
+        qWarning() << "Failed to fetch timeline:" << reply->errorString();
     }
     reply->deleteLater();
 }

--- a/src/PullRequestWindow.h
+++ b/src/PullRequestWindow.h
@@ -28,8 +28,8 @@ class PullRequestWindow : public KXmlGuiWindow {
     void fetchPrDetails();
     void onPrDetailsReply(QNetworkReply* reply);
 
-    void fetchComments();
-    void onCommentsReply(QNetworkReply* reply);
+    void fetchTimeline();
+    void onTimelineReply(QNetworkReply* reply);
 
     void fetchReviewComments();
     void onReviewCommentsReply(QNetworkReply* reply);
@@ -80,6 +80,7 @@ class PullRequestWindow : public KXmlGuiWindow {
     QString m_reviewCommentsUrl;
     QString m_commitsUrl;
     QString m_issueCommentsUrl;
+    QString m_timelineUrl;
 
     void setupUi();
     void addCommentToUI(const QString& author, const QString& body, const QString& createdAt);


### PR DESCRIPTION
Transitions the PR "Conversation" tab from using the `/comments` endpoint to the GitHub API `/timeline` endpoint.
It now successfully parses and displays various events such as 'committed', 'assigned', 'labeled', 'closed', 'merged', 'reviewed', and others alongside normal comments.

---
*PR created automatically by Jules for task [15842150803729870120](https://jules.google.com/task/15842150803729870120) started by @arran4*