### PR TITLE
Fix clang-format violations in PullRequestWindow.cpp

### DIFF
--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -585,7 +585,7 @@ void PullRequestWindow::setupMenus() {
     QAction* openUrlAction = new QAction(QIcon::fromTheme("internet-web-browser"), tr("Open PR in Browser"), this);
     connect(openUrlAction, &QAction::triggered, this, [this]() {
         const QUrl url(GitHubClient::apiToHtmlUrl(m_notification.url, m_notification.id));
-   if (url.isValid() && (url.scheme() == "http" || url.scheme() == "https")) {
+        if (url.isValid() && (url.scheme() == "http" || url.scheme() == "https")) {
             if (!QDesktopServices::openUrl(url)) {
                 QMessageBox::warning(this, tr("Error"), tr("Failed to open the URL in your web browser."));
             }


### PR DESCRIPTION
Fixes a simple `clang-format` indentation issue in `src/PullRequestWindow.cpp` that was failing the continuous integration build. This fix consists entirely of whitespace adjustments, so no functional changes were made. Tests were run in the builder container to ensure the build still succeeds.

---
*PR created automatically by Jules for task [11650348346916294316](https://jules.google.com/task/11650348346916294316) started by @arran4*