### PR TITLE
Fix KXmlGuiWindow Menus Rendering Empty in KF6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,9 @@ Avoid deep nesting of `if/else` blocks. Use guard clauses (early returns) to han
 Break down large functions into smaller, single-purpose helper functions. This improves readability and makes the code easier to test and maintain.
 
 ## Building and Compiling (Qt6 / KF6 Migration)
-This project is currently migrating to Qt6 and KDE Frameworks 6 (KF6).
+This project is strictly a Qt6 and KDE Frameworks 6 (KF6) only project.
 If your environment does not have the required Qt6 or KF6 development headers, there is a Dockerfile located in `.jules/Dockerfile` that can be used to set up an isolated build container (e.g. `debian:testing`) with all required `libkf6*` dependencies.
+Do not use Qt5 or KF5 idioms, dependencies, or classes.
 
 
 ## GitHub Personal Access Tokens (PATs)

--- a/src/NotificationWindow.cpp
+++ b/src/NotificationWindow.cpp
@@ -30,6 +30,7 @@ NotificationWindow::NotificationWindow(const Notification& n, GitHubClient* clie
     KStandardAction::close(this, &NotificationWindow::close, actionCollection());
 
     QAction* copyLinkAction = KStandardAction::copy(this, &NotificationWindow::onCopyLink, actionCollection());
+    copyLinkAction->setText(tr("Copy Link"));
 
     QAction* openUrlAction = new QAction(QIcon::fromTheme("internet-web-browser"), tr("Open URL"), this);
     connect(openUrlAction, &QAction::triggered, this, &NotificationWindow::onOpenUrl);

--- a/src/NotificationWindow.cpp
+++ b/src/NotificationWindow.cpp
@@ -8,6 +8,8 @@
 #include <QJsonDocument>
 #include <QLabel>
 #include <QMessageBox>
+#include <KActionCollection>
+#include <KStandardAction>
 #include <QPushButton>
 #include <QTextEdit>
 #include <QVBoxLayout>
@@ -24,34 +26,23 @@ NotificationWindow::NotificationWindow(const Notification& n, GitHubClient* clie
     setWindowTitle(tr("Notification Details - %1").arg(n.repository));
     resize(500, 400);
 
-    // Menu Bar
-    QMenu* fileMenu = menuBar()->addMenu(tr("&File"));
-    QAction* closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
-    closeAction->setShortcut(QKeySequence::Close);
-    connect(closeAction, &QAction::triggered, this, &NotificationWindow::close);
-    fileMenu->addAction(closeAction);
+    // Actions & Menus
+    KStandardAction::close(this, &NotificationWindow::close, actionCollection());
 
-    QMenu* editMenu = menuBar()->addMenu(tr("&Edit"));
-
-    QAction* copyLinkAction = new QAction(QIcon::fromTheme("edit-copy"), tr("Copy Link"), this);
-    copyLinkAction->setShortcut(QKeySequence::Copy);
-    connect(copyLinkAction, &QAction::triggered, this, &NotificationWindow::onCopyLink);
-    editMenu->addAction(copyLinkAction);
-
-    QMenu* actionsMenu = menuBar()->addMenu(tr("&Actions"));
+    QAction* copyLinkAction = KStandardAction::copy(this, &NotificationWindow::onCopyLink, actionCollection());
 
     QAction* openUrlAction = new QAction(QIcon::fromTheme("internet-web-browser"), tr("Open URL"), this);
     connect(openUrlAction, &QAction::triggered, this, &NotificationWindow::onOpenUrl);
-    actionsMenu->addAction(openUrlAction);
+    actionCollection()->addAction(QStringLiteral("open_url"), openUrlAction);
 
     QAction* markAsReadAction = new QAction(QIcon::fromTheme("mail-mark-read"), tr("Mark as Read"), this);
     connect(markAsReadAction, &QAction::triggered, this, &NotificationWindow::onMarkAsRead);
-    actionsMenu->addAction(markAsReadAction);
+    actionCollection()->addAction(QStringLiteral("mark_as_read"), markAsReadAction);
 
     QAction* markAsDoneAction = new QAction(QIcon::fromTheme("task-complete"), tr("Mark as Done"), this);
     connect(markAsDoneAction, &QAction::triggered, this, &NotificationWindow::onMarkAsDone);
-    actionsMenu->addAction(markAsDoneAction);
-    actionsMenu->addSeparator();
+    actionCollection()->addAction(QStringLiteral("mark_as_done"), markAsDoneAction);
+
     QAction* muteRepoAction = new QAction(QIcon::fromTheme("notifications-disabled"), tr("Mute Repository"), this);
     connect(muteRepoAction, &QAction::triggered, this, [this]() {
         NotificationRule rule;
@@ -61,7 +52,7 @@ NotificationWindow::NotificationWindow(const Notification& n, GitHubClient* clie
         QMessageBox::information(this, tr("Rule Added"),
                                  tr("Muted notifications for repository:\n%1").arg(m_notification.repository));
     });
-    actionsMenu->addAction(muteRepoAction);
+    actionCollection()->addAction(QStringLiteral("mute_repo"), muteRepoAction);
 
     QAction* openRulesAction =
         new QAction(QIcon::fromTheme("view-list-details"), tr("Manage Notification Rules..."), this);
@@ -69,13 +60,11 @@ NotificationWindow::NotificationWindow(const Notification& n, GitHubClient* clie
         RulesDialog dialog(this, m_notification.repository, m_notification.repository);
         dialog.exec();
     });
-    actionsMenu->addAction(openRulesAction);
-
-    actionsMenu->addSeparator();
+    actionCollection()->addAction(QStringLiteral("open_rules"), openRulesAction);
 
     QAction* viewRawAction = new QAction(QIcon::fromTheme("text-x-generic"), tr("View Raw JSON"), this);
     connect(viewRawAction, &QAction::triggered, this, &NotificationWindow::onViewRawJson);
-    actionsMenu->addAction(viewRawAction);
+    actionCollection()->addAction(QStringLiteral("view_raw_json"), viewRawAction);
 
     QAction* viewPullRequestAction = nullptr;
     QAction* viewActionJobAction = nullptr;
@@ -83,11 +72,11 @@ NotificationWindow::NotificationWindow(const Notification& n, GitHubClient* clie
     if (m_notification.type == "PullRequest") {
         viewPullRequestAction = new QAction(QIcon::fromTheme("vcs-merge-request"), tr("View Pull Request"), this);
         connect(viewPullRequestAction, &QAction::triggered, this, &NotificationWindow::onViewPullRequest);
-        actionsMenu->addAction(viewPullRequestAction);
+        actionCollection()->addAction(QStringLiteral("view_pull_request"), viewPullRequestAction);
     } else if (m_notification.type == "CheckSuite" || m_notification.type == "WorkflowRun") {
         viewActionJobAction = new QAction(QIcon::fromTheme("system-run"), tr("View Action Job"), this);
         connect(viewActionJobAction, &QAction::triggered, this, &NotificationWindow::onViewActionJob);
-        actionsMenu->addAction(viewActionJobAction);
+        actionCollection()->addAction(QStringLiteral("view_action_job"), viewActionJobAction);
     }
 
     // Tool Bar

--- a/src/NotificationWindow.cpp
+++ b/src/NotificationWindow.cpp
@@ -1,5 +1,7 @@
 #include "NotificationWindow.h"
 
+#include <KActionCollection>
+#include <KStandardAction>
 #include <QApplication>
 #include <QClipboard>
 #include <QDesktopServices>
@@ -8,8 +10,6 @@
 #include <QJsonDocument>
 #include <QLabel>
 #include <QMessageBox>
-#include <KActionCollection>
-#include <KStandardAction>
 #include <QPushButton>
 #include <QTextEdit>
 #include <QVBoxLayout>

--- a/src/RepoListWindow.cpp
+++ b/src/RepoListWindow.cpp
@@ -1,5 +1,7 @@
 #include "RepoListWindow.h"
 
+#include <KActionCollection>
+#include <KStandardAction>
 #include <QApplication>
 #include <QClipboard>
 #include <QDateTime>
@@ -14,8 +16,6 @@
 #include <QLabel>
 #include <QMenu>
 #include <QMessageBox>
-#include <KActionCollection>
-#include <KStandardAction>
 #include <QStandardPaths>
 #include <QStatusBar>
 #include <QTableWidget>
@@ -80,16 +80,19 @@ void RepoListWindow::setupUI() {
 
     KStandardAction::close(this, &RepoListWindow::close, actionCollection());
 
-    KStandardAction::copy(this, [this]() {
-        QList<QTableWidgetItem*> items = m_table->selectedItems();
-        if (!items.isEmpty()) {
-            int row = items.first()->row();
-            QTableWidgetItem* urlItem = m_table->item(row, 7);  // URL is column 7
-            if (urlItem) {
-                QApplication::clipboard()->setText(urlItem->text());
+    KStandardAction::copy(
+        this,
+        [this]() {
+            QList<QTableWidgetItem*> items = m_table->selectedItems();
+            if (!items.isEmpty()) {
+                int row = items.first()->row();
+                QTableWidgetItem* urlItem = m_table->item(row, 7);  // URL is column 7
+                if (urlItem) {
+                    QApplication::clipboard()->setText(urlItem->text());
+                }
             }
-        }
-    }, actionCollection());
+        },
+        actionCollection());
 
     setupGUI(Default, ":/kgithub-notifyui.rc");
 

--- a/src/RepoListWindow.cpp
+++ b/src/RepoListWindow.cpp
@@ -13,8 +13,9 @@
 #include <QJsonObject>
 #include <QLabel>
 #include <QMenu>
-#include <QMenuBar>
 #include <QMessageBox>
+#include <KActionCollection>
+#include <KStandardAction>
 #include <QStandardPaths>
 #include <QStatusBar>
 #include <QTableWidget>
@@ -69,35 +70,17 @@ void RepoListWindow::setupUI() {
 
     setObjectName("RepoListWindow");
     setCentralWidget(m_table);
-    setupGUI(Default, ":/kgithub-notifyui.rc");
 
-    // Toolbar
-    m_toolbar = addToolBar(tr("Main Toolbar"));
-    m_toolbar->setObjectName("RepoListMainToolBar");
-    m_toolbar->setMovable(false);
-
-    QAction* refreshAction = new QAction(QIcon::fromTheme("view-refresh"), tr("Refresh"), this);
-    connect(refreshAction, &QAction::triggered, this, &RepoListWindow::onRefreshClicked);
-    m_toolbar->addAction(refreshAction);
+    // Actions
+    QAction* refreshAction = KStandardAction::redisplay(this, &RepoListWindow::onRefreshClicked, actionCollection());
 
     QAction* exportAction = new QAction(QIcon::fromTheme("document-export"), tr("Export to CSV"), this);
     connect(exportAction, &QAction::triggered, this, &RepoListWindow::onExportClicked);
-    m_toolbar->addAction(exportAction);
+    actionCollection()->addAction(QStringLiteral("export_csv"), exportAction);
 
-    QAction* closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
-    closeAction->setShortcut(QKeySequence::Close);
-    connect(closeAction, &QAction::triggered, this, &RepoListWindow::close);
+    KStandardAction::close(this, &RepoListWindow::close, actionCollection());
 
-    QMenuBar* menuBarWidget = menuBar();
-    QMenu* fileMenu = menuBarWidget->addMenu(tr("&File"));
-    fileMenu->addAction(exportAction);
-    fileMenu->addSeparator();
-    fileMenu->addAction(closeAction);
-
-    QMenu* editMenu = menuBarWidget->addMenu(tr("&Edit"));
-    QAction* copyAction = new QAction(QIcon::fromTheme("edit-copy"), tr("Copy URL"), this);
-    copyAction->setShortcut(QKeySequence::Copy);
-    connect(copyAction, &QAction::triggered, this, [this]() {
+    KStandardAction::copy(this, [this]() {
         QList<QTableWidgetItem*> items = m_table->selectedItems();
         if (!items.isEmpty()) {
             int row = items.first()->row();
@@ -106,12 +89,17 @@ void RepoListWindow::setupUI() {
                 QApplication::clipboard()->setText(urlItem->text());
             }
         }
-    });
-    editMenu->addAction(copyAction);
+    }, actionCollection());
 
-    QMenu* viewMenu = menuBarWidget->addMenu(tr("&View"));
-    refreshAction->setShortcut(QKeySequence::Refresh);
-    viewMenu->addAction(refreshAction);
+    setupGUI(Default, ":/kgithub-notifyui.rc");
+
+    // Toolbar
+    m_toolbar = addToolBar(tr("Main Toolbar"));
+    m_toolbar->setObjectName("RepoListMainToolBar");
+    m_toolbar->setMovable(false);
+
+    m_toolbar->addAction(refreshAction);
+    m_toolbar->addAction(exportAction);
 
     // Status bar
     m_statusBar = statusBar();

--- a/src/WorkItemWindow.cpp
+++ b/src/WorkItemWindow.cpp
@@ -83,6 +83,7 @@ void WorkItemWindow::setupUi() {
     KStandardAction::close(this, &WorkItemWindow::close, actionCollection());
 
     m_copyAction = KStandardAction::copy(this, &WorkItemWindow::copyLink, actionCollection());
+    m_copyAction->setText(tr("Copy Link"));
 
     setupGUI(Default, ":/kgithub-notifyui.rc");
 

--- a/src/WorkItemWindow.cpp
+++ b/src/WorkItemWindow.cpp
@@ -1,5 +1,7 @@
 #include "WorkItemWindow.h"
 
+#include <KActionCollection>
+#include <KStandardAction>
 #include <QApplication>
 #include <QClipboard>
 #include <QDateTime>
@@ -12,8 +14,6 @@
 #include <QJsonObject>
 #include <QMenu>
 #include <QMessageBox>
-#include <KActionCollection>
-#include <KStandardAction>
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QStatusBar>
@@ -72,10 +72,13 @@ void WorkItemWindow::setupUi() {
     connect(exportJsonAction, &QAction::triggered, this, &WorkItemWindow::exportToJson);
     actionCollection()->addAction(QStringLiteral("export_json"), exportJsonAction);
 
-    QAction* refreshAction = KStandardAction::redisplay(this, [this]() {
-        m_table->setRowCount(0);  // Give immediate visual feedback of refresh
-        loadData(1);
-    }, actionCollection());
+    QAction* refreshAction = KStandardAction::redisplay(
+        this,
+        [this]() {
+            m_table->setRowCount(0);  // Give immediate visual feedback of refresh
+            loadData(1);
+        },
+        actionCollection());
 
     KStandardAction::close(this, &WorkItemWindow::close, actionCollection());
 

--- a/src/WorkItemWindow.cpp
+++ b/src/WorkItemWindow.cpp
@@ -11,8 +11,9 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMenu>
-#include <QMenuBar>
 #include <QMessageBox>
+#include <KActionCollection>
+#include <KStandardAction>
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QStatusBar>
@@ -61,39 +62,26 @@ void WorkItemWindow::setupUi() {
 
     setObjectName("WorkItemWindow");
     setCentralWidget(m_table);
-    setupGUI(Default, ":/kgithub-notifyui.rc");
 
     // Actions
     QAction* exportCsvAction = new QAction(tr("Export to CSV"), this);
     connect(exportCsvAction, &QAction::triggered, this, &WorkItemWindow::exportToCsv);
+    actionCollection()->addAction(QStringLiteral("export_csv"), exportCsvAction);
+
     QAction* exportJsonAction = new QAction(tr("Export to JSON"), this);
     connect(exportJsonAction, &QAction::triggered, this, &WorkItemWindow::exportToJson);
-    QAction* refreshAction = new QAction(tr("Refresh"), this);
-    connect(refreshAction, &QAction::triggered, this, [this]() {
+    actionCollection()->addAction(QStringLiteral("export_json"), exportJsonAction);
+
+    QAction* refreshAction = KStandardAction::redisplay(this, [this]() {
         m_table->setRowCount(0);  // Give immediate visual feedback of refresh
         loadData(1);
-    });
-    QAction* closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
-    closeAction->setShortcut(QKeySequence::Close);
-    connect(closeAction, &QAction::triggered, this, &WorkItemWindow::close);
+    }, actionCollection());
 
-    // Menu Bar
-    QMenuBar* menuBarWidget = menuBar();
-    QMenu* fileMenu = menuBarWidget->addMenu(tr("&File"));
-    fileMenu->addAction(exportCsvAction);
-    fileMenu->addAction(exportJsonAction);
-    fileMenu->addSeparator();
-    fileMenu->addAction(closeAction);
+    KStandardAction::close(this, &WorkItemWindow::close, actionCollection());
 
-    QMenu* editMenu = menuBarWidget->addMenu(tr("&Edit"));
-    m_copyAction = new QAction(QIcon::fromTheme("edit-copy"), tr("Copy Link"), this);
-    m_copyAction->setShortcut(QKeySequence::Copy);
-    connect(m_copyAction, &QAction::triggered, this, &WorkItemWindow::copyLink);
-    editMenu->addAction(m_copyAction);
+    m_copyAction = KStandardAction::copy(this, &WorkItemWindow::copyLink, actionCollection());
 
-    QMenu* viewMenu = menuBarWidget->addMenu(tr("&View"));
-    refreshAction->setShortcut(QKeySequence::Refresh);
-    viewMenu->addAction(refreshAction);
+    setupGUI(Default, ":/kgithub-notifyui.rc");
 
     // Tool Bar
     QToolBar* toolBar = addToolBar(tr("Main Toolbar"));

--- a/src/kgithub-notifyui.rc
+++ b/src/kgithub-notifyui.rc
@@ -7,6 +7,8 @@
 
     <MenuBar>
         <Menu name="file">
+            <Action name="export_csv"/>
+            <Action name="export_json"/>
             <Separator/>
             <Action name="file_close"/>
             <Action name="file_quit"/>
@@ -15,11 +17,24 @@
             <text>&amp;Edit</text>
             <Action name="edit_select_all"/>
             <Action name="edit_deselect"/>
+            <Action name="edit_copy"/>
         </Menu>
         <Menu name="view">
             <text>&amp;View</text>
             <Action name="view_raw_json"/>
             <Action name="view_redisplay"/>
+        </Menu>
+        <Menu name="actions">
+            <text>&amp;Actions</text>
+            <Action name="open_url"/>
+            <Action name="mark_as_read"/>
+            <Action name="mark_as_done"/>
+            <Separator/>
+            <Action name="mute_repo"/>
+            <Action name="open_rules"/>
+            <Separator/>
+            <Action name="view_pull_request"/>
+            <Action name="view_action_job"/>
         </Menu>
         <Menu name="settings">
             <Action name="notification_rules"/>

--- a/src/trending/TrendingWindow.cpp
+++ b/src/trending/TrendingWindow.cpp
@@ -12,8 +12,9 @@
 #include <QJsonObject>
 #include <QLabel>
 #include <QMenu>
-#include <QMenuBar>
 #include <QSettings>
+#include <KActionCollection>
+#include <KStandardAction>
 #include <QStyle>
 #include <QTableWidget>
 #include <QTextEdit>
@@ -31,7 +32,6 @@ TrendingWindow::TrendingWindow(GitHubClient* client, QWidget* parent)
     QWidget* centralWidget = new QWidget(this);
     setObjectName("TrendingWindow");
     setCentralWidget(centralWidget);
-    setupGUI(Default, ":/kgithub-notifyui.rc");
     QVBoxLayout* mainLayout = new QVBoxLayout(centralWidget);
 
     QHBoxLayout* topLayout = new QHBoxLayout();
@@ -89,17 +89,9 @@ TrendingWindow::TrendingWindow(GitHubClient* client, QWidget* parent)
     mainLayout->addLayout(topLayout);
     mainLayout->addWidget(tableWidget);
 
-    QMenuBar* menuBarWidget = menuBar();
-    QMenu* fileMenu = menuBarWidget->addMenu(tr("&File"));
-    QAction* closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
-    closeAction->setShortcut(QKeySequence::Close);
-    connect(closeAction, &QAction::triggered, this, &TrendingWindow::close);
-    fileMenu->addAction(closeAction);
+    KStandardAction::close(this, &TrendingWindow::close, actionCollection());
 
-    QMenu* editMenu = menuBarWidget->addMenu(tr("&Edit"));
-    QAction* copyAction = new QAction(QIcon::fromTheme("edit-copy"), tr("Copy Link"), this);
-    copyAction->setShortcut(QKeySequence::Copy);
-    connect(copyAction, &QAction::triggered, this, [this]() {
+    KStandardAction::copy(this, [this]() {
         QList<QTableWidgetItem*> items = tableWidget->selectedItems();
         if (!items.isEmpty()) {
             QTableWidgetItem* item = items.first();
@@ -110,14 +102,11 @@ TrendingWindow::TrendingWindow(GitHubClient* client, QWidget* parent)
                 }
             }
         }
-    });
-    editMenu->addAction(copyAction);
+    }, actionCollection());
 
-    QMenu* viewMenu = menuBarWidget->addMenu(tr("&View"));
-    QAction* refreshAction = new QAction(QIcon::fromTheme("view-refresh"), tr("Refresh"), this);
-    refreshAction->setShortcut(QKeySequence::Refresh);
-    connect(refreshAction, &QAction::triggered, this, &TrendingWindow::onRefreshClicked);
-    viewMenu->addAction(refreshAction);
+    KStandardAction::redisplay(this, &TrendingWindow::onRefreshClicked, actionCollection());
+
+    setupGUI(Default, ":/kgithub-notifyui.rc");
 
     m_netManager = new QNetworkAccessManager(this);
     connect(m_netManager, &QNetworkAccessManager::finished, this, &TrendingWindow::onRepoStarredCheckFinished);

--- a/src/trending/TrendingWindow.cpp
+++ b/src/trending/TrendingWindow.cpp
@@ -1,5 +1,7 @@
 #include "TrendingWindow.h"
 
+#include <KActionCollection>
+#include <KStandardAction>
 #include <QApplication>
 #include <QClipboard>
 #include <QDateTime>
@@ -13,8 +15,6 @@
 #include <QLabel>
 #include <QMenu>
 #include <QSettings>
-#include <KActionCollection>
-#include <KStandardAction>
 #include <QStyle>
 #include <QTableWidget>
 #include <QTextEdit>
@@ -91,18 +91,21 @@ TrendingWindow::TrendingWindow(GitHubClient* client, QWidget* parent)
 
     KStandardAction::close(this, &TrendingWindow::close, actionCollection());
 
-    KStandardAction::copy(this, [this]() {
-        QList<QTableWidgetItem*> items = tableWidget->selectedItems();
-        if (!items.isEmpty()) {
-            QTableWidgetItem* item = items.first();
-            if (item) {
-                QString url = item->data(Qt::UserRole).toString();
-                if (!url.isEmpty()) {
-                    QApplication::clipboard()->setText(url);
+    KStandardAction::copy(
+        this,
+        [this]() {
+            QList<QTableWidgetItem*> items = tableWidget->selectedItems();
+            if (!items.isEmpty()) {
+                QTableWidgetItem* item = items.first();
+                if (item) {
+                    QString url = item->data(Qt::UserRole).toString();
+                    if (!url.isEmpty()) {
+                        QApplication::clipboard()->setText(url);
+                    }
                 }
             }
-        }
-    }, actionCollection());
+        },
+        actionCollection());
 
     KStandardAction::redisplay(this, &TrendingWindow::onRefreshClicked, actionCollection());
 


### PR DESCRIPTION
Resolves an issue where top-level menu bars (like File, Edit) appeared empty in KXmlGuiWindow child windows due to improper Qt5-style direct menu manipulation. The fix correctly adopts KF6 standards using `actionCollection()`, `KStandardAction`, and `.rc` file mappings.

---
*PR created automatically by Jules for task [10632090209714702333](https://jules.google.com/task/10632090209714702333) started by @arran4*