### PR TITLE
Make secondary windows free-floating and independent

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -447,7 +447,8 @@ void MainWindow::showAboutDialog() {
 
 void MainWindow::showDebugWindow(const QString& url) {
     if (!debugWindow) {
-        debugWindow = new DebugWindow(client, this);
+        debugWindow = new DebugWindow(client, nullptr);
+        debugWindow->setAttribute(Qt::WA_DeleteOnClose);
     }
     if (!url.isEmpty()) debugWindow->setEndpoint(url);
     debugWindow->show();
@@ -457,7 +458,7 @@ void MainWindow::showDebugWindow(const QString& url) {
 
 void MainWindow::showRepoListWindow() {
     if (!repoListWindow) {
-        repoListWindow = new RepoListWindow(client, this);
+        repoListWindow = new RepoListWindow(client, nullptr);
     }
     repoListWindow->show();
     repoListWindow->raise();
@@ -466,7 +467,7 @@ void MainWindow::showRepoListWindow() {
 
 void MainWindow::showTrendingWindow() {
     if (!trendingWindow) {
-        trendingWindow = new TrendingWindow(client, this);
+        trendingWindow = new TrendingWindow(client, nullptr);
     }
     trendingWindow->show();
     trendingWindow->raise();
@@ -986,7 +987,7 @@ void MainWindow::setupMenus() {
 void MainWindow::showWorkItems(const QString& title, int endpointType, const QString& query) {
     WorkItemWindow::EndpointType type =
         (endpointType == 0) ? WorkItemWindow::EndpointIssues : WorkItemWindow::EndpointRepositories;
-    WorkItemWindow* window = new WorkItemWindow(client, title, type, query, this);
+    WorkItemWindow* window = new WorkItemWindow(client, title, type, query, nullptr);
     window->setAttribute(Qt::WA_DeleteOnClose);
     window->show();
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -9,6 +9,7 @@
 #include <QLabel>
 #include <QMenu>
 #include <QMessageBox>
+#include <QPointer>
 #include <QPushButton>
 #include <QStackedWidget>
 #include <QStatusBar>
@@ -105,9 +106,9 @@ class MainWindow : public KXmlGuiWindow {
     void updateTrayIconState(int unreadCount, int newNotifications, const QList<Notification>& newlyAddedNotifications);
 
     // Member Variables
-    DebugWindow* debugWindow;
-    RepoListWindow* repoListWindow;
-    TrendingWindow* trendingWindow;
+    QPointer<DebugWindow> debugWindow;
+    QPointer<RepoListWindow> repoListWindow;
+    QPointer<TrendingWindow> trendingWindow;
     QSystemTrayIcon* trayIcon;
     QMenu* trayIconMenu;
     NotificationListWidget* notificationListWidget;


### PR DESCRIPTION
Fixes an issue where secondary windows would block or impact the main window. Made them completely free-floating and updated internal tracking to use `QPointer` to prevent dangling pointers.

---
*PR created automatically by Jules for task [491757888694832119](https://jules.google.com/task/491757888694832119) started by @arran4*