### PR TITLE
Convert GitHub UTC dates to user's local time and locale

### DIFF
--- a/src/NotificationItemWidget.cpp
+++ b/src/NotificationItemWidget.cpp
@@ -96,7 +96,7 @@ NotificationItemWidget::NotificationItemWidget(const Notification& n, QWidget* p
     // Date
     // Parse date
     QDateTime dt = QDateTime::fromString(n.updatedAt, Qt::ISODate);
-    QString dateStr = dt.isValid() ? QLocale::system().toString(dt, QLocale::ShortFormat) : n.updatedAt;
+    QString dateStr = dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : n.updatedAt;
 
     dateLabel = new QLabel("Date: " + dateStr, this);
     contentLayout->addWidget(dateLabel);
@@ -305,7 +305,7 @@ void NotificationItemWidget::updateNotification(const Notification& n) {
     }
 
     QDateTime dt = QDateTime::fromString(n.updatedAt, Qt::ISODate);
-    QString dateStr = dt.isValid() ? QLocale::system().toString(dt, QLocale::ShortFormat) : n.updatedAt;
+    QString dateStr = dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : n.updatedAt;
     QString dateLabelText = "Date: " + dateStr;
     if (dateLabel->text() != dateLabelText) {
         dateLabel->setText(dateLabelText);

--- a/src/NotificationItemWidget.cpp
+++ b/src/NotificationItemWidget.cpp
@@ -96,7 +96,7 @@ NotificationItemWidget::NotificationItemWidget(const Notification& n, QWidget* p
     // Date
     // Parse date
     QDateTime dt = QDateTime::fromString(n.updatedAt, Qt::ISODate);
-    QString dateStr = dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : n.updatedAt;
+    QString dateStr = dt.isValid() ? QLocale().toString(dt.toLocalTime(), QLocale::ShortFormat) : n.updatedAt;
 
     dateLabel = new QLabel("Date: " + dateStr, this);
     contentLayout->addWidget(dateLabel);
@@ -305,7 +305,7 @@ void NotificationItemWidget::updateNotification(const Notification& n) {
     }
 
     QDateTime dt = QDateTime::fromString(n.updatedAt, Qt::ISODate);
-    QString dateStr = dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : n.updatedAt;
+    QString dateStr = dt.isValid() ? QLocale().toString(dt.toLocalTime(), QLocale::ShortFormat) : n.updatedAt;
     QString dateLabelText = "Date: " + dateStr;
     if (dateLabel->text() != dateLabelText) {
         dateLabel->setText(dateLabelText);

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -263,12 +263,14 @@ void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
         m_openedByLabel->setText(tr("<b>Opened by:</b> %1").arg(author));
 
         QDateTime createdDt = QDateTime::fromString(createdAt, Qt::ISODate);
-        QString createdStr = createdDt.isValid() ? QLocale::system().toString(createdDt.toLocalTime(), QLocale::ShortFormat) : tr("N/A");
+        QString createdStr =
+            createdDt.isValid() ? QLocale::system().toString(createdDt.toLocalTime(), QLocale::ShortFormat) : tr("N/A");
         m_createdAtLabel->setText(tr("<b>Created:</b> %1").arg(createdStr));
 
         QString updatedAt = obj["updated_at"].toString();
         QDateTime updatedDt = QDateTime::fromString(updatedAt, Qt::ISODate);
-        QString updatedStr = updatedDt.isValid() ? QLocale::system().toString(updatedDt.toLocalTime(), QLocale::ShortFormat) : tr("N/A");
+        QString updatedStr =
+            updatedDt.isValid() ? QLocale::system().toString(updatedDt.toLocalTime(), QLocale::ShortFormat) : tr("N/A");
         m_updatedAtLabel->setText(tr("<b>Updated:</b> %1").arg(updatedStr));
 
         // Update Metadata

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -263,12 +263,12 @@ void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
         m_openedByLabel->setText(tr("<b>Opened by:</b> %1").arg(author));
 
         QDateTime createdDt = QDateTime::fromString(createdAt, Qt::ISODate);
-        QString createdStr = createdDt.isValid() ? QLocale().toString(createdDt, QLocale::ShortFormat) : tr("N/A");
+        QString createdStr = createdDt.isValid() ? QLocale::system().toString(createdDt.toLocalTime(), QLocale::ShortFormat) : tr("N/A");
         m_createdAtLabel->setText(tr("<b>Created:</b> %1").arg(createdStr));
 
         QString updatedAt = obj["updated_at"].toString();
         QDateTime updatedDt = QDateTime::fromString(updatedAt, Qt::ISODate);
-        QString updatedStr = updatedDt.isValid() ? QLocale().toString(updatedDt, QLocale::ShortFormat) : tr("N/A");
+        QString updatedStr = updatedDt.isValid() ? QLocale::system().toString(updatedDt.toLocalTime(), QLocale::ShortFormat) : tr("N/A");
         m_updatedAtLabel->setText(tr("<b>Updated:</b> %1").arg(updatedStr));
 
         // Update Metadata
@@ -409,7 +409,7 @@ void PullRequestWindow::onTimelineReply(QNetworkReply* reply) {
                 if (!text.isEmpty()) {
                     if (!createdAt.isEmpty()) {
                         QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
-                        QString formattedDate = QLocale().toString(dt, QLocale::ShortFormat);
+                        QString formattedDate = QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat);
                         text += tr(" on %1").arg(formattedDate);
                     }
                     QLabel* label = new QLabel(text);
@@ -549,7 +549,7 @@ void PullRequestWindow::onFileDoubleClicked(int row, int column) {
 
 void PullRequestWindow::addCommentToUI(const QString& author, const QString& body, const QString& createdAt) {
     QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
-    QString formattedDate = QLocale().toString(dt, QLocale::ShortFormat);
+    QString formattedDate = QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat);
 
     CommentWidget* widget = new CommentWidget(author, body, formattedDate);
     m_commentsContainerLayout->addWidget(widget);

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -264,13 +264,13 @@ void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
 
         QDateTime createdDt = QDateTime::fromString(createdAt, Qt::ISODate);
         QString createdStr =
-            createdDt.isValid() ? QLocale::system().toString(createdDt.toLocalTime(), QLocale::ShortFormat) : tr("N/A");
+            createdDt.isValid() ? QLocale().toString(createdDt.toLocalTime(), QLocale::ShortFormat) : tr("N/A");
         m_createdAtLabel->setText(tr("<b>Created:</b> %1").arg(createdStr));
 
         QString updatedAt = obj["updated_at"].toString();
         QDateTime updatedDt = QDateTime::fromString(updatedAt, Qt::ISODate);
         QString updatedStr =
-            updatedDt.isValid() ? QLocale::system().toString(updatedDt.toLocalTime(), QLocale::ShortFormat) : tr("N/A");
+            updatedDt.isValid() ? QLocale().toString(updatedDt.toLocalTime(), QLocale::ShortFormat) : tr("N/A");
         m_updatedAtLabel->setText(tr("<b>Updated:</b> %1").arg(updatedStr));
 
         // Update Metadata
@@ -411,7 +411,8 @@ void PullRequestWindow::onTimelineReply(QNetworkReply* reply) {
                 if (!text.isEmpty()) {
                     if (!createdAt.isEmpty()) {
                         QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
-                        QString formattedDate = QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat);
+                        QString formattedDate =
+                            dt.isValid() ? QLocale().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
                         text += tr(" on %1").arg(formattedDate);
                     }
                     QLabel* label = new QLabel(text);
@@ -551,7 +552,7 @@ void PullRequestWindow::onFileDoubleClicked(int row, int column) {
 
 void PullRequestWindow::addCommentToUI(const QString& author, const QString& body, const QString& createdAt) {
     QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
-    QString formattedDate = QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat);
+    QString formattedDate = dt.isValid() ? QLocale().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
 
     CommentWidget* widget = new CommentWidget(author, body, formattedDate);
     m_commentsContainerLayout->addWidget(widget);

--- a/src/RepoListWindow.cpp
+++ b/src/RepoListWindow.cpp
@@ -206,8 +206,8 @@ void RepoListWindow::addReposToTable(const QJsonArray& repos) {
             QDateTime m_date;
         };
 
-        QTableWidgetItem* updatedItem =
-            new DateTableItem(QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat), dt);
+        QTableWidgetItem* updatedItem = new DateTableItem(
+            dt.isValid() ? QLocale().toString(dt.toLocalTime(), QLocale::ShortFormat) : updatedStr, dt);
 
         QTableWidgetItem* urlItem = new QTableWidgetItem(repo["html_url"].toString());
 

--- a/src/RepoListWindow.cpp
+++ b/src/RepoListWindow.cpp
@@ -206,7 +206,8 @@ void RepoListWindow::addReposToTable(const QJsonArray& repos) {
             QDateTime m_date;
         };
 
-        QTableWidgetItem* updatedItem = new DateTableItem(QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat), dt);
+        QTableWidgetItem* updatedItem =
+            new DateTableItem(QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat), dt);
 
         QTableWidgetItem* urlItem = new QTableWidgetItem(repo["html_url"].toString());
 

--- a/src/RepoListWindow.cpp
+++ b/src/RepoListWindow.cpp
@@ -206,7 +206,7 @@ void RepoListWindow::addReposToTable(const QJsonArray& repos) {
             QDateTime m_date;
         };
 
-        QTableWidgetItem* updatedItem = new DateTableItem(QLocale::system().toString(dt, QLocale::ShortFormat), dt);
+        QTableWidgetItem* updatedItem = new DateTableItem(QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat), dt);
 
         QTableWidgetItem* urlItem = new QTableWidgetItem(repo["html_url"].toString());
 

--- a/src/WorkItemWindow.cpp
+++ b/src/WorkItemWindow.cpp
@@ -215,8 +215,7 @@ void WorkItemWindow::appendRow(const QJsonObject& item) {
         QTableWidgetItem* authorItem = new QTableWidgetItem(author);
 
         QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
-        QString displayDate =
-            dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
+        QString displayDate = dt.isValid() ? QLocale().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
         QTableWidgetItem* createdItem = new QTableWidgetItem(displayDate);
 
         // Store the URL in the title item for easy access later
@@ -241,8 +240,7 @@ void WorkItemWindow::appendRow(const QJsonObject& item) {
         QTableWidgetItem* ownerItem = new QTableWidgetItem(owner);
 
         QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
-        QString displayDate =
-            dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
+        QString displayDate = dt.isValid() ? QLocale().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
         QTableWidgetItem* createdItem = new QTableWidgetItem(displayDate);
 
         // Store the URL in the repo item

--- a/src/WorkItemWindow.cpp
+++ b/src/WorkItemWindow.cpp
@@ -5,7 +5,6 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QDateTime>
-#include <QLocale>
 #include <QDesktopServices>
 #include <QFile>
 #include <QFileDialog>
@@ -13,6 +12,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QLocale>
 #include <QMenu>
 #include <QMessageBox>
 #include <QRegularExpression>
@@ -215,7 +215,8 @@ void WorkItemWindow::appendRow(const QJsonObject& item) {
         QTableWidgetItem* authorItem = new QTableWidgetItem(author);
 
         QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
-        QString displayDate = dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
+        QString displayDate =
+            dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
         QTableWidgetItem* createdItem = new QTableWidgetItem(displayDate);
 
         // Store the URL in the title item for easy access later
@@ -240,7 +241,8 @@ void WorkItemWindow::appendRow(const QJsonObject& item) {
         QTableWidgetItem* ownerItem = new QTableWidgetItem(owner);
 
         QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
-        QString displayDate = dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
+        QString displayDate =
+            dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
         QTableWidgetItem* createdItem = new QTableWidgetItem(displayDate);
 
         // Store the URL in the repo item

--- a/src/WorkItemWindow.cpp
+++ b/src/WorkItemWindow.cpp
@@ -5,6 +5,7 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QDateTime>
+#include <QLocale>
 #include <QDesktopServices>
 #include <QFile>
 #include <QFileDialog>
@@ -212,7 +213,10 @@ void WorkItemWindow::appendRow(const QJsonObject& item) {
         QTableWidgetItem* titleItem = new QTableWidgetItem(title);
         QTableWidgetItem* stateItem = new QTableWidgetItem(state);
         QTableWidgetItem* authorItem = new QTableWidgetItem(author);
-        QTableWidgetItem* createdItem = new QTableWidgetItem(createdAt);
+
+        QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
+        QString displayDate = dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
+        QTableWidgetItem* createdItem = new QTableWidgetItem(displayDate);
 
         // Store the URL in the title item for easy access later
         titleItem->setData(Qt::UserRole, htmlUrl);
@@ -234,7 +238,10 @@ void WorkItemWindow::appendRow(const QJsonObject& item) {
         QTableWidgetItem* descItem = new QTableWidgetItem(description);
         QTableWidgetItem* langItem = new QTableWidgetItem(language);
         QTableWidgetItem* ownerItem = new QTableWidgetItem(owner);
-        QTableWidgetItem* createdItem = new QTableWidgetItem(createdAt);
+
+        QDateTime dt = QDateTime::fromString(createdAt, Qt::ISODate);
+        QString displayDate = dt.isValid() ? QLocale::system().toString(dt.toLocalTime(), QLocale::ShortFormat) : createdAt;
+        QTableWidgetItem* createdItem = new QTableWidgetItem(displayDate);
 
         // Store the URL in the repo item
         repoItem->setData(Qt::UserRole, htmlUrl);


### PR DESCRIPTION
Converts all UTC dates from GitHub API to local timezone before rendering them in the UI. Uses QLocale::system() with toLocalTime().

---
*PR created automatically by Jules for task [10237196895610473571](https://jules.google.com/task/10237196895610473571) started by @arran4*