### PR TITLE
Fix PAT leak by authenticating only to trusted API origin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ enable_testing()
 add_executable(TestGitHubClient
     tests/TestGitHubClient.cpp
     tests/MockNetworkReply.cpp
+    tests/FakeNetworkAccessManager.cpp
     tests/MockNetworkReply.h
     src/GitHubClient.cpp
     src/GitHubClient.h

--- a/src/GitHubClient.cpp
+++ b/src/GitHubClient.cpp
@@ -173,6 +173,12 @@ void GitHubClient::requestRaw(const QString& endpoint, const QString& method, co
     if (m_token.isEmpty()) return;
     QString urlStr = endpoint.startsWith("http") ? endpoint : m_apiUrl + endpoint;
     QUrl url(urlStr);
+
+    if (!isTrustedApiOrigin(url)) {
+        emit rawDataReceived("Error: Untrusted external destination for authenticated request.");
+        return;
+    }
+
     QNetworkRequest request = createAuthenticatedRequest(url);
 
     if (!body.isEmpty()) {
@@ -218,33 +224,59 @@ void GitHubClient::fetchUserRepos(const QString& pageUrl) {
     reply->setProperty("type", "repos");
 }
 
+bool GitHubClient::isTrustedApiOrigin(const QUrl& url) const {
+    QUrl apiOrigin(m_apiUrl);
+
+    // Compare scheme
+    if (url.scheme().compare(apiOrigin.scheme(), Qt::CaseInsensitive) != 0) {
+        return false;
+    }
+
+    // Compare host
+    if (url.host().compare(apiOrigin.host(), Qt::CaseInsensitive) != 0) {
+        return false;
+    }
+
+    // Compare port
+    int urlPort = url.port(url.scheme() == "https" ? 443 : 80);
+    int apiPort = apiOrigin.port(apiOrigin.scheme() == "https" ? 443 : 80);
+
+    return urlPort == apiPort;
+}
+
 QNetworkRequest GitHubClient::createAuthenticatedRequest(const QUrl& url) const { return createRequest(url); }
 
 QNetworkRequest GitHubClient::createRequest(const QUrl& url) const {
     QNetworkRequest request(url);
 
-    // Add Authorization header
-    QByteArray authHeader = "token ";
-    QByteArray tokenBytes = m_token.toQByteArray();
-    authHeader.append(tokenBytes);
+    if (isTrustedApiOrigin(url)) {
+        // Add Authorization header only for trusted origins
+        QByteArray authHeader = "token ";
+        QByteArray tokenBytes = m_token.toQByteArray();
+        authHeader.append(tokenBytes);
 
-    request.setRawHeader("Authorization", authHeader);
+        request.setRawHeader("Authorization", authHeader);
+
+        // Explicitly zero out sensitive data
+        if (!tokenBytes.isEmpty()) {
+            volatile char* p = tokenBytes.data();
+            size_t s = tokenBytes.size();
+            while (s--) *p++ = 0;
+        }
+        if (!authHeader.isEmpty()) {
+            volatile char* p = authHeader.data();
+            size_t s = authHeader.size();
+            while (s--) *p++ = 0;
+        }
+    }
+
     request.setRawHeader("Accept", "application/vnd.github.v3+json");
-
-    // Explicitly zero out sensitive data
-    if (!tokenBytes.isEmpty()) {
-        volatile char* p = tokenBytes.data();
-        size_t s = tokenBytes.size();
-        while (s--) *p++ = 0;
-    }
-    if (!authHeader.isEmpty()) {
-        volatile char* p = authHeader.data();
-        size_t s = authHeader.size();
-        while (s--) *p++ = 0;
-    }
 
     // Add user-agent header as required by GitHub API
     request.setRawHeader("User-Agent", "Kgithub-notify");
+
+    // Check redirect behavior so credentials cannot leak to a different origin
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::SameOriginRedirectPolicy);
 
     return request;
 }

--- a/src/GitHubClient.cpp
+++ b/src/GitHubClient.cpp
@@ -90,9 +90,10 @@ void GitHubClient::loadMore() {
 
     if (!isTrustedApiOrigin(url)) {
         m_nextPageUrl.clear();
-        emit errorOccurred("Untrusted pagination URL rejected.");
-        // Signal completion with empty data and no more pages
+        // Signal completion with empty data and no more pages before emitting error
+        // so completion handlers do not overwrite the error status
         emit notificationsReceived(QList<Notification>(), true, false);
+        emit errorOccurred("Untrusted pagination URL rejected.");
         return;
     }
 
@@ -447,6 +448,7 @@ void GitHubClient::handleUserReposReply(QNetworkReply* reply) {
     }
 
     QString nextPageUrl;
+    bool linkRejected = false;
     if (reply->hasRawHeader("Link")) {
         QString linkHeader = reply->rawHeader("Link");
         QRegularExpression re("<([^>]+)>;\\s*rel=\"next\"");
@@ -455,11 +457,15 @@ void GitHubClient::handleUserReposReply(QNetworkReply* reply) {
             nextPageUrl = match.captured(1);
             if (!isTrustedApiOrigin(QUrl(nextPageUrl))) {
                 nextPageUrl.clear();
+                linkRejected = true;
             }
         }
     }
 
     emit userReposReceived(doc.array(), nextPageUrl);
+    if (linkRejected) {
+        emit errorOccurred("Untrusted repository pagination URL rejected.");
+    }
 }
 
 void GitHubClient::handlePatchReply(QNetworkReply* reply) {
@@ -546,6 +552,7 @@ void GitHubClient::handleNotificationsReply(QNetworkReply* reply) {
 
     // Parse Link header
     m_nextPageUrl.clear();
+    bool linkRejected = false;
     if (reply->hasRawHeader("Link")) {
         QString linkHeader = reply->rawHeader("Link");
         // Example: <https://api.github.com/resource?page=2>; rel="next", <https://api.github.com/resource?page=5>;
@@ -556,12 +563,16 @@ void GitHubClient::handleNotificationsReply(QNetworkReply* reply) {
             m_nextPageUrl = match.captured(1);
             if (!isTrustedApiOrigin(QUrl(m_nextPageUrl))) {
                 m_nextPageUrl.clear();
+                linkRejected = true;
             }
         }
     }
 
     bool append = reply->property("append").toBool();
     emit notificationsReceived(notifications, append, !m_nextPageUrl.isEmpty());
+    if (linkRejected) {
+        emit errorOccurred("Untrusted pagination URL rejected.");
+    }
 }
 
 void GitHubClient::onRequestTimeout() {

--- a/src/GitHubClient.cpp
+++ b/src/GitHubClient.cpp
@@ -453,6 +453,9 @@ void GitHubClient::handleUserReposReply(QNetworkReply* reply) {
         QRegularExpressionMatch match = re.match(linkHeader);
         if (match.hasMatch()) {
             nextPageUrl = match.captured(1);
+            if (!isTrustedApiOrigin(QUrl(nextPageUrl))) {
+                nextPageUrl.clear();
+            }
         }
     }
 
@@ -551,6 +554,9 @@ void GitHubClient::handleNotificationsReply(QNetworkReply* reply) {
         QRegularExpressionMatch match = re.match(linkHeader);
         if (match.hasMatch()) {
             m_nextPageUrl = match.captured(1);
+            if (!isTrustedApiOrigin(QUrl(m_nextPageUrl))) {
+                m_nextPageUrl.clear();
+            }
         }
     }
 

--- a/src/GitHubClient.cpp
+++ b/src/GitHubClient.cpp
@@ -87,6 +87,15 @@ void GitHubClient::loadMore() {
     }
 
     QUrl url(m_nextPageUrl);
+
+    if (!isTrustedApiOrigin(url)) {
+        m_nextPageUrl.clear();
+        emit errorOccurred("Untrusted pagination URL rejected.");
+        // Signal completion with empty data and no more pages
+        emit notificationsReceived(QList<Notification>(), true, false);
+        return;
+    }
+
     QNetworkRequest request = createAuthenticatedRequest(url);
 
     QNetworkReply* reply = manager->get(request);
@@ -151,6 +160,12 @@ void GitHubClient::fetchNotificationDetails(const QString& url, const QString& n
     if (m_token.isEmpty() || url.isEmpty()) return;
     QUrl qUrl(url);
     if (!qUrl.isValid()) return;
+
+    if (!isTrustedApiOrigin(qUrl)) {
+        emit errorOccurred("Untrusted notification details URL rejected.");
+        return;
+    }
+
     QNetworkRequest request = createRequest(qUrl);
     QNetworkReply* reply = manager->get(request);
     reply->setProperty("type", "details");
@@ -217,6 +232,11 @@ void GitHubClient::fetchUserRepos(const QString& pageUrl) {
         url.setQuery(query);
     } else {
         url = QUrl(pageUrl);
+    }
+
+    if (!isTrustedApiOrigin(url)) {
+        emit errorOccurred("Untrusted repository pagination URL rejected.");
+        return;
     }
 
     QNetworkRequest request = createAuthenticatedRequest(url);

--- a/src/GitHubClient.h
+++ b/src/GitHubClient.h
@@ -68,6 +68,7 @@ class GitHubClient : public QObject {
     QPointer<QNetworkReply> m_activeNotificationReply;
     QTimer* m_requestTimeoutTimer;
 
+    bool isTrustedApiOrigin(const QUrl& url) const;
     QNetworkRequest createRequest(const QUrl& url) const;
 
     void handleDetailsReply(QNetworkReply* reply);

--- a/tests/FakeNetworkAccessManager.cpp
+++ b/tests/FakeNetworkAccessManager.cpp
@@ -1,0 +1,1 @@
+#include "FakeNetworkAccessManager.h"

--- a/tests/FakeNetworkAccessManager.h
+++ b/tests/FakeNetworkAccessManager.h
@@ -1,0 +1,40 @@
+#ifndef FAKENETWORKACCESSMANAGER_H
+#define FAKENETWORKACCESSMANAGER_H
+
+#include <QList>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+
+class FakeNetworkReply : public QNetworkReply {
+    Q_OBJECT
+   public:
+    explicit FakeNetworkReply(QObject* parent = nullptr) : QNetworkReply(parent) {
+        setOpenMode(QIODevice::ReadOnly);
+        QMetaObject::invokeMethod(this, "finished", Qt::QueuedConnection);
+    }
+    void abort() override {}
+    qint64 readData(char*, qint64) override { return 0; }
+};
+
+class FakeNetworkAccessManager : public QNetworkAccessManager {
+    Q_OBJECT
+   public:
+    explicit FakeNetworkAccessManager(QObject* parent = nullptr) : QNetworkAccessManager(parent) {}
+
+    struct RequestRecord {
+        Operation op;
+        QNetworkRequest request;
+    };
+    QList<RequestRecord> requests;
+
+   protected:
+    QNetworkReply* createRequest(Operation op, const QNetworkRequest& request,
+                                 QIODevice* outgoingData = nullptr) override {
+        Q_UNUSED(outgoingData);
+        requests.append({op, request});
+        return new FakeNetworkReply(this);
+    }
+};
+
+#endif  // FAKENETWORKACCESSMANAGER_H

--- a/tests/TestGitHubClient.cpp
+++ b/tests/TestGitHubClient.cpp
@@ -2,6 +2,7 @@
 #include <QtTest>
 
 #include "../src/GitHubClient.h"
+#include "FakeNetworkAccessManager.h"
 #include "MockNetworkReply.h"
 
 // Declare Q_DECLARE_METATYPE for QList<Notification> so QSignalSpy can handle it
@@ -15,84 +16,92 @@ class TestGitHubClient : public QObject {
         qRegisterMetaType<QList<Notification>>("QList<Notification>");
     }
 
-    void testTrustedOrigin() {
+    void testProductionRequests() {
         GitHubClient client;
+        FakeNetworkAccessManager* fakeManager = new FakeNetworkAccessManager(&client);
+
+        // Replace the default manager with our fake
+        // Since test is a friend class, we can just replace the member
+        QNetworkAccessManager* oldManager = client.manager;
+        client.manager = fakeManager;
+        oldManager->deleteLater();
+
         client.setApiUrl("https://api.github.com");
         client.setToken("dummy_token");
 
-        // Helper to extract authorization header
-        auto getAuthHeader = [](GitHubClient& c, const QString& urlStr) -> QByteArray {
-            QNetworkRequest request = c.createAuthenticatedRequest(QUrl(urlStr));
-            return request.rawHeader("Authorization");
-        };
+        QSignalSpy rawDataSpy(&client, &GitHubClient::rawDataReceived);
+        QSignalSpy errorSpy(&client, &GitHubClient::errorOccurred);
 
-        // 1. Configured API origin
-        QCOMPARE(getAuthHeader(client, "https://api.github.com/user"), QByteArray("token dummy_token"));
-
-        // 2. Relative URL simulation (in practice it prepends m_apiUrl, so same as above)
-        QCOMPARE(getAuthHeader(client, "https://api.github.com/notifications"), QByteArray("token dummy_token"));
-
-        // 3. Different host
-        QCOMPARE(getAuthHeader(client, "https://external.example.com/api"), QByteArray(""));
-
-        // 4. api.github.com.evil.example
-        QCOMPARE(getAuthHeader(client, "https://api.github.com.evil.example/user"), QByteArray(""));
-
-        // 5. HTTPS-to-HTTP downgrade
-        QCOMPARE(getAuthHeader(client, "http://api.github.com/user"), QByteArray(""));
-
-        // 6. Explicit/default ports
-        QCOMPARE(getAuthHeader(client, "https://api.github.com:443/user"), QByteArray("token dummy_token"));
-        QCOMPARE(getAuthHeader(client, "https://api.github.com:8443/user"), QByteArray(""));
-
-        // 7. Configured test API origin (Enterprise base)
-        client.setApiUrl("https://git.example.internal/api/v3");
-        QCOMPARE(getAuthHeader(client, "https://git.example.internal/api/v3/user"), QByteArray("token dummy_token"));
-        QCOMPARE(getAuthHeader(client, "https://git.example.internal:443/api/v3/user"),
-                 QByteArray("token dummy_token"));
-        QCOMPARE(getAuthHeader(client, "http://git.example.internal/api/v3/user"), QByteArray(""));
-    }
-
-    void testUntrustedPaginationAndAvatars() {
-        GitHubClient client;
-        client.setApiUrl("https://api.github.com");
-        client.setToken("dummy_token");
-
-        // Simulate untrusted pagination URL
-        QNetworkRequest req = client.createAuthenticatedRequest(QUrl("https://evil.com/notifications?page=2"));
-        QCOMPARE(req.rawHeader("Authorization"), QByteArray(""));
-
-        // Let's verify same origin redirect policy is applied
-        QCOMPARE(req.attribute(QNetworkRequest::RedirectPolicyAttribute).toInt(),
+        // 1. requestRaw("/user") resolves against configured API base and carries token
+        client.requestRaw("/user");
+        QCOMPARE(fakeManager->requests.size(), 1);
+        QCOMPARE(fakeManager->requests.last().request.url(), QUrl("https://api.github.com/user"));
+        QCOMPARE(fakeManager->requests.last().request.rawHeader("Authorization"), QByteArray("token dummy_token"));
+        QCOMPARE(fakeManager->requests.last().request.attribute(QNetworkRequest::RedirectPolicyAttribute).toInt(),
                  QNetworkRequest::SameOriginRedirectPolicy);
 
-        // Avatar request having no Authorization header
-        QNetworkRequest reqAvatar;
-        // fetchImage uses QNetworkRequest directly, but it just calls manager->get with that request.
-        // We can use a spy or similar to inspect it if manager was injectable, or we can just mock it.
-        // Actually, fetchImage doesn't use createAuthenticatedRequest, it just does:
-        // QNetworkRequest request(QUrl(imageUrl));
-        // We can't easily intercept the request inside fetchImage without a full MockNetworkAccessManager.
-        // However, we can simulate the logic here, or we can use the MockNetworkReply pattern if it intercepts.
-        // Let's create a subclass of QNetworkAccessManager or just check what the code does.
-        // Since we can't easily test internal requests without refactoring GitHubClient to inject a factory,
-        // let's verify fetchImage doesn't call createAuthenticatedRequest. It's evident from the code.
-        // We'll write a simple test for avatar fetching that ensures it triggers network request.
-        QSignalSpy spyDetails(&client, &GitHubClient::detailsReceived);
+        // 2. external debug destination emits clear error and dispatches zero requests
+        int reqCountBefore = fakeManager->requests.size();
+        client.requestRaw("https://external.example.com/api");
+        QCOMPARE(fakeManager->requests.size(), reqCountBefore);
+        QCOMPARE(rawDataSpy.count(), 1);
+        QCOMPARE(rawDataSpy.takeFirst().at(0).toString(),
+                 QString("Error: Untrusted external destination for authenticated request."));
 
-        // Wait, fetchImage emits detailsReceived? No, it's handled by handleImageReply.
-        // Let's test it using MockNetworkReply if possible.
-        // Actually we just skip the complex MockNetworkAccessManager and just mock the reply for fetchImage.
-        MockNetworkReply* reply = new MockNetworkReply(QByteArray("image_data"), &client);
-        reply->setProperty("type", "image");
-        reply->setProperty("notificationId", "123");
+        // 3. external next links / direct pagination inputs dispatch zero requests
+        client.m_nextPageUrl = "https://evil.com/notifications?page=2";
+        client.loadMore();
+        QCOMPARE(fakeManager->requests.size(), reqCountBefore);
+        QCOMPARE(errorSpy.count(), 1);
+        QCOMPARE(errorSpy.takeFirst().at(0).toString(), QString("Untrusted pagination URL rejected."));
 
-        // Emitting finished on a mocked reply doesn't test the request header.
-        // For the scope of this unit test, let's just make sure `createRequest` handles an untrusted avatar URL
-        // correctly if it were used:
-        QNetworkRequest reqAvatarFallback =
-            client.createAuthenticatedRequest(QUrl("https://avatars.githubusercontent.com/u/12345?v=4"));
-        QCOMPARE(reqAvatarFallback.rawHeader("Authorization"), QByteArray(""));
+        client.fetchUserRepos("https://evil.com/user/repos?page=2");
+        QCOMPARE(fakeManager->requests.size(), reqCountBefore);
+        QCOMPARE(errorSpy.count(), 1);
+        QCOMPARE(errorSpy.takeFirst().at(0).toString(), QString("Untrusted repository pagination URL rejected."));
+
+        client.fetchNotificationDetails("https://evil.com/notifications/threads/123", "123");
+        QCOMPARE(fakeManager->requests.size(), reqCountBefore);
+        QCOMPARE(errorSpy.count(), 1);
+        QCOMPARE(errorSpy.takeFirst().at(0).toString(), QString("Untrusted notification details URL rejected."));
+
+        // 4. trusted pagination still carries auth
+        client.m_nextPageUrl = "https://api.github.com/notifications?page=2";
+        client.loadMore();
+        QCOMPARE(fakeManager->requests.size(), reqCountBefore + 1);
+        QCOMPARE(fakeManager->requests.last().request.url(), QUrl("https://api.github.com/notifications?page=2"));
+        QCOMPARE(fakeManager->requests.last().request.rawHeader("Authorization"), QByteArray("token dummy_token"));
+        QCOMPARE(fakeManager->requests.last().request.attribute(QNetworkRequest::RedirectPolicyAttribute).toInt(),
+                 QNetworkRequest::SameOriginRedirectPolicy);
+
+        // 5. actual fetchImage() requests omit Authorization, including an image hosted on the trusted origin
+        reqCountBefore = fakeManager->requests.size();
+        client.fetchImage("https://avatars.githubusercontent.com/u/12345?v=4", "123");
+        QCOMPARE(fakeManager->requests.size(), reqCountBefore + 1);
+        QCOMPARE(fakeManager->requests.last().request.url(), QUrl("https://avatars.githubusercontent.com/u/12345?v=4"));
+        QCOMPARE(fakeManager->requests.last().request.rawHeader("Authorization"), QByteArray(""));
+
+        client.fetchImage("https://api.github.com/image.png", "123");
+        QCOMPARE(fakeManager->requests.size(), reqCountBefore + 2);
+        QCOMPARE(fakeManager->requests.last().request.url(), QUrl("https://api.github.com/image.png"));
+        QCOMPARE(fakeManager->requests.last().request.rawHeader("Authorization"), QByteArray(""));
+
+        // 6. Enterprise cases (trusted origin)
+        client.setApiUrl("https://git.example.internal/api/v3");
+        client.requestRaw("/user");
+        QCOMPARE(fakeManager->requests.last().request.url(), QUrl("https://git.example.internal/api/v3/user"));
+        QCOMPARE(fakeManager->requests.last().request.rawHeader("Authorization"), QByteArray("token dummy_token"));
+
+        // Scheme / Host / Port mismatch checks
+        client.requestRaw("http://git.example.internal/api/v3/user");  // Downgrade
+        QCOMPARE(rawDataSpy.count(), 1);
+        QCOMPARE(rawDataSpy.takeFirst().at(0).toString(),
+                 QString("Error: Untrusted external destination for authenticated request."));
+
+        client.requestRaw("https://git.example.internal:8443/api/v3/user");  // Wrong port
+        QCOMPARE(rawDataSpy.count(), 1);
+        QCOMPARE(rawDataSpy.takeFirst().at(0).toString(),
+                 QString("Error: Untrusted external destination for authenticated request."));
     }
 
     void testNotificationsDispatch() {

--- a/tests/TestGitHubClient.cpp
+++ b/tests/TestGitHubClient.cpp
@@ -15,6 +15,86 @@ class TestGitHubClient : public QObject {
         qRegisterMetaType<QList<Notification>>("QList<Notification>");
     }
 
+    void testTrustedOrigin() {
+        GitHubClient client;
+        client.setApiUrl("https://api.github.com");
+        client.setToken("dummy_token");
+
+        // Helper to extract authorization header
+        auto getAuthHeader = [](GitHubClient& c, const QString& urlStr) -> QByteArray {
+            QNetworkRequest request = c.createAuthenticatedRequest(QUrl(urlStr));
+            return request.rawHeader("Authorization");
+        };
+
+        // 1. Configured API origin
+        QCOMPARE(getAuthHeader(client, "https://api.github.com/user"), QByteArray("token dummy_token"));
+
+        // 2. Relative URL simulation (in practice it prepends m_apiUrl, so same as above)
+        QCOMPARE(getAuthHeader(client, "https://api.github.com/notifications"), QByteArray("token dummy_token"));
+
+        // 3. Different host
+        QCOMPARE(getAuthHeader(client, "https://external.example.com/api"), QByteArray(""));
+
+        // 4. api.github.com.evil.example
+        QCOMPARE(getAuthHeader(client, "https://api.github.com.evil.example/user"), QByteArray(""));
+
+        // 5. HTTPS-to-HTTP downgrade
+        QCOMPARE(getAuthHeader(client, "http://api.github.com/user"), QByteArray(""));
+
+        // 6. Explicit/default ports
+        QCOMPARE(getAuthHeader(client, "https://api.github.com:443/user"), QByteArray("token dummy_token"));
+        QCOMPARE(getAuthHeader(client, "https://api.github.com:8443/user"), QByteArray(""));
+
+        // 7. Configured test API origin (Enterprise base)
+        client.setApiUrl("https://git.example.internal/api/v3");
+        QCOMPARE(getAuthHeader(client, "https://git.example.internal/api/v3/user"), QByteArray("token dummy_token"));
+        QCOMPARE(getAuthHeader(client, "https://git.example.internal:443/api/v3/user"),
+                 QByteArray("token dummy_token"));
+        QCOMPARE(getAuthHeader(client, "http://git.example.internal/api/v3/user"), QByteArray(""));
+    }
+
+    void testUntrustedPaginationAndAvatars() {
+        GitHubClient client;
+        client.setApiUrl("https://api.github.com");
+        client.setToken("dummy_token");
+
+        // Simulate untrusted pagination URL
+        QNetworkRequest req = client.createAuthenticatedRequest(QUrl("https://evil.com/notifications?page=2"));
+        QCOMPARE(req.rawHeader("Authorization"), QByteArray(""));
+
+        // Let's verify same origin redirect policy is applied
+        QCOMPARE(req.attribute(QNetworkRequest::RedirectPolicyAttribute).toInt(),
+                 QNetworkRequest::SameOriginRedirectPolicy);
+
+        // Avatar request having no Authorization header
+        QNetworkRequest reqAvatar;
+        // fetchImage uses QNetworkRequest directly, but it just calls manager->get with that request.
+        // We can use a spy or similar to inspect it if manager was injectable, or we can just mock it.
+        // Actually, fetchImage doesn't use createAuthenticatedRequest, it just does:
+        // QNetworkRequest request(QUrl(imageUrl));
+        // We can't easily intercept the request inside fetchImage without a full MockNetworkAccessManager.
+        // However, we can simulate the logic here, or we can use the MockNetworkReply pattern if it intercepts.
+        // Let's create a subclass of QNetworkAccessManager or just check what the code does.
+        // Since we can't easily test internal requests without refactoring GitHubClient to inject a factory,
+        // let's verify fetchImage doesn't call createAuthenticatedRequest. It's evident from the code.
+        // We'll write a simple test for avatar fetching that ensures it triggers network request.
+        QSignalSpy spyDetails(&client, &GitHubClient::detailsReceived);
+
+        // Wait, fetchImage emits detailsReceived? No, it's handled by handleImageReply.
+        // Let's test it using MockNetworkReply if possible.
+        // Actually we just skip the complex MockNetworkAccessManager and just mock the reply for fetchImage.
+        MockNetworkReply* reply = new MockNetworkReply(QByteArray("image_data"), &client);
+        reply->setProperty("type", "image");
+        reply->setProperty("notificationId", "123");
+
+        // Emitting finished on a mocked reply doesn't test the request header.
+        // For the scope of this unit test, let's just make sure `createRequest` handles an untrusted avatar URL
+        // correctly if it were used:
+        QNetworkRequest reqAvatarFallback =
+            client.createAuthenticatedRequest(QUrl("https://avatars.githubusercontent.com/u/12345?v=4"));
+        QCOMPARE(reqAvatarFallback.rawHeader("Authorization"), QByteArray(""));
+    }
+
     void testNotificationsDispatch() {
         GitHubClient client;
         QSignalSpy spy(&client, &GitHubClient::notificationsReceived);

--- a/tests/TestGitHubClient.cpp
+++ b/tests/TestGitHubClient.cpp
@@ -16,6 +16,44 @@ class TestGitHubClient : public QObject {
         qRegisterMetaType<QList<Notification>>("QList<Notification>");
     }
 
+    void testTrustedOrigin() {
+        GitHubClient client;
+        client.setApiUrl("https://api.github.com");
+        client.setToken("dummy_token");
+
+        // Helper to extract authorization header using invokeMethod
+        auto getAuthHeader = [](GitHubClient& c, const QString& urlStr) -> QByteArray {
+            QNetworkRequest request = c.createAuthenticatedRequest(QUrl(urlStr));
+            return request.rawHeader("Authorization");
+        };
+
+        // 1. Configured API origin
+        QCOMPARE(getAuthHeader(client, "https://api.github.com/user"), QByteArray("token dummy_token"));
+
+        // 2. Relative URL simulation (in practice it prepends m_apiUrl, so same as above)
+        QCOMPARE(getAuthHeader(client, "https://api.github.com/notifications"), QByteArray("token dummy_token"));
+
+        // 3. Different host
+        QCOMPARE(getAuthHeader(client, "https://external.example.com/api"), QByteArray(""));
+
+        // 4. api.github.com.evil.example
+        QCOMPARE(getAuthHeader(client, "https://api.github.com.evil.example/user"), QByteArray(""));
+
+        // 5. HTTPS-to-HTTP downgrade
+        QCOMPARE(getAuthHeader(client, "http://api.github.com/user"), QByteArray(""));
+
+        // 6. Explicit/default ports
+        QCOMPARE(getAuthHeader(client, "https://api.github.com:443/user"), QByteArray("token dummy_token"));
+        QCOMPARE(getAuthHeader(client, "https://api.github.com:8443/user"), QByteArray(""));
+
+        // 7. Configured test API origin (Enterprise base)
+        client.setApiUrl("https://git.example.internal/api/v3");
+        QCOMPARE(getAuthHeader(client, "https://git.example.internal/api/v3/user"), QByteArray("token dummy_token"));
+        QCOMPARE(getAuthHeader(client, "https://git.example.internal:443/api/v3/user"),
+                 QByteArray("token dummy_token"));
+        QCOMPARE(getAuthHeader(client, "http://git.example.internal/api/v3/user"), QByteArray(""));
+    }
+
     void testProductionRequests() {
         GitHubClient client;
         FakeNetworkAccessManager* fakeManager = new FakeNetworkAccessManager(&client);
@@ -102,6 +140,57 @@ class TestGitHubClient : public QObject {
         QCOMPARE(rawDataSpy.count(), 1);
         QCOMPARE(rawDataSpy.takeFirst().at(0).toString(),
                  QString("Error: Untrusted external destination for authenticated request."));
+    }
+
+    void testUntrustedPaginationLinkHeaders() {
+        GitHubClient client;
+        client.setApiUrl("https://api.github.com");
+
+        QSignalSpy notifySpy(&client, &GitHubClient::notificationsReceived);
+        QSignalSpy repoSpy(&client, &GitHubClient::userReposReceived);
+
+        // Test untrusted link header in notifications
+        QByteArray jsonNotifications = "[]";
+        MockNetworkReply* replyNotifications = new MockNetworkReply(jsonNotifications, &client);
+        replyNotifications->setProperty("type", "notifications");
+        replyNotifications->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
+        replyNotifications->setRawHeader("Link", "<https://external.example/notifications?page=2>; rel=\"next\"");
+
+        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection,
+                                  Q_ARG(QNetworkReply*, replyNotifications));
+
+        QCOMPARE(notifySpy.count(), 1);
+        QList<QVariant> argsNotify = notifySpy.takeFirst();
+        bool hasMoreNotify = argsNotify.at(2).toBool();
+        QCOMPARE(hasMoreNotify, false);
+
+        // Test untrusted link header in user repos
+        QByteArray jsonRepos = "[]";
+        MockNetworkReply* replyRepos = new MockNetworkReply(jsonRepos, &client);
+        replyRepos->setProperty("type", "repos");
+        replyRepos->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
+        replyRepos->setRawHeader("Link", "<https://external.example/repos?page=2>; rel=\"next\"");
+
+        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, replyRepos));
+
+        QCOMPARE(repoSpy.count(), 1);
+        QList<QVariant> argsRepo = repoSpy.takeFirst();
+        QString nextUrlRepo = argsRepo.at(1).toString();
+        QCOMPARE(nextUrlRepo, QString(""));
+
+        // Test trusted link header in notifications
+        MockNetworkReply* replyNotificationsTrusted = new MockNetworkReply(jsonNotifications, &client);
+        replyNotificationsTrusted->setProperty("type", "notifications");
+        replyNotificationsTrusted->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
+        replyNotificationsTrusted->setRawHeader("Link", "<https://api.github.com/notifications?page=2>; rel=\"next\"");
+
+        QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection,
+                                  Q_ARG(QNetworkReply*, replyNotificationsTrusted));
+
+        QCOMPARE(notifySpy.count(), 1);
+        QList<QVariant> argsNotifyTrusted = notifySpy.takeFirst();
+        bool hasMoreNotifyTrusted = argsNotifyTrusted.at(2).toBool();
+        QCOMPARE(hasMoreNotifyTrusted, true);
     }
 
     void testNotificationsDispatch() {

--- a/tests/TestGitHubClient.cpp
+++ b/tests/TestGitHubClient.cpp
@@ -88,8 +88,13 @@ class TestGitHubClient : public QObject {
 
         // 3. external next links / direct pagination inputs dispatch zero requests
         client.m_nextPageUrl = "https://evil.com/notifications?page=2";
+        QSignalSpy loadMoreNotifySpy(&client, &GitHubClient::notificationsReceived);
         client.loadMore();
         QCOMPARE(fakeManager->requests.size(), reqCountBefore);
+
+        // Assert notificationsReceived happens BEFORE errorOccurred
+        // QSignalSpy only gives counts, but we can verify both fired
+        QCOMPARE(loadMoreNotifySpy.count(), 1);
         QCOMPARE(errorSpy.count(), 1);
         QCOMPARE(errorSpy.takeFirst().at(0).toString(), QString("Untrusted pagination URL rejected."));
 
@@ -148,6 +153,7 @@ class TestGitHubClient : public QObject {
 
         QSignalSpy notifySpy(&client, &GitHubClient::notificationsReceived);
         QSignalSpy repoSpy(&client, &GitHubClient::userReposReceived);
+        QSignalSpy errorSpy(&client, &GitHubClient::errorOccurred);
 
         // Test untrusted link header in notifications
         QByteArray jsonNotifications = "[]";
@@ -164,6 +170,9 @@ class TestGitHubClient : public QObject {
         bool hasMoreNotify = argsNotify.at(2).toBool();
         QCOMPARE(hasMoreNotify, false);
 
+        QCOMPARE(errorSpy.count(), 1);
+        QCOMPARE(errorSpy.takeFirst().at(0).toString(), QString("Untrusted pagination URL rejected."));
+
         // Test untrusted link header in user repos
         QByteArray jsonRepos = "[]";
         MockNetworkReply* replyRepos = new MockNetworkReply(jsonRepos, &client);
@@ -178,6 +187,9 @@ class TestGitHubClient : public QObject {
         QString nextUrlRepo = argsRepo.at(1).toString();
         QCOMPARE(nextUrlRepo, QString(""));
 
+        QCOMPARE(errorSpy.count(), 1);
+        QCOMPARE(errorSpy.takeFirst().at(0).toString(), QString("Untrusted repository pagination URL rejected."));
+
         // Test trusted link header in notifications
         MockNetworkReply* replyNotificationsTrusted = new MockNetworkReply(jsonNotifications, &client);
         replyNotificationsTrusted->setProperty("type", "notifications");
@@ -191,6 +203,8 @@ class TestGitHubClient : public QObject {
         QList<QVariant> argsNotifyTrusted = notifySpy.takeFirst();
         bool hasMoreNotifyTrusted = argsNotifyTrusted.at(2).toBool();
         QCOMPARE(hasMoreNotifyTrusted, true);
+
+        QCOMPARE(errorSpy.count(), 0);  // No error for trusted pagination
     }
 
     void testNotificationsDispatch() {


### PR DESCRIPTION
Restricts GitHub PAT Authorization headers to the configured API origin using scheme, host, and effective-port matching. Requests created by the central helper use a same-origin redirect policy. The Debug GitHub API request path rejects external destinations with a clear error. Image fetching remains unauthenticated.

Fixes #277

### Validation and review

- CI/CD run 34096058809 passed the Qt/C++ build and test steps for head `5d7dc57fc2cc874b22c0dd2061aa64cfce791d2a`.
- External pagination/detail requests are rejected before dispatch. Both Link parsers discard external next URLs. Direct origin/header regression tests and offline production-request tests are present.
- Pagination rejection errors are emitted after result/state updates in both Link handlers and the defensive loadMore path, preserving the final error status.
- Review: no remaining blocking findings at this head; approval communicated in ChatGPT, with no GitHub approval submitted and no merge performed. Tests were not rerun locally during this review.
- Non-blocking test limitation: signal tests verify counts and error messages but do not assert relative signal order; the production emission order was checked directly.

---
*PR created automatically by Jules for task [4575938644500817570](https://jules.google.com/task/4575938644500817570) started by @arran4*