### PR TITLE
Complete shared GitHub request lifecycle and consumer isolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,3 +163,13 @@ install(FILES src/kgithub-notifyui.rc
 install(FILES src/com.arran4.kgithub_notify.metainfo.xml
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo
 )
+
+# Exercise the real consumers with manually completed network replies.
+get_target_property(consumer_sources kgithub-notify SOURCES)
+list(REMOVE_ITEM consumer_sources src/main.cpp)
+add_executable(TestRequestConsumers tests/TestRequestConsumers.cpp
+    tests/FakeNetworkAccessManager.cpp ${consumer_sources})
+get_target_property(consumer_libraries kgithub-notify LINK_LIBRARIES)
+target_link_libraries(TestRequestConsumers PRIVATE ${consumer_libraries} Qt6::Test)
+add_test(NAME TestRequestConsumers COMMAND TestRequestConsumers)
+set_tests_properties(TestRequestConsumers PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/src/ActionWindow.cpp
+++ b/src/ActionWindow.cpp
@@ -5,17 +5,25 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMessageBox>
+#include <QStatusBar>
 
-ActionWindow::ActionWindow(const Notification& n, GitHubClient* client, QWidget* parent)
+ActionWindow::ActionWindow(const Notification& n, GitHubClient* client, QWidget* parent,
+                           QNetworkAccessManager* networkManager)
     : KXmlGuiWindow(parent, Qt::Window),
       m_notification(n),
       m_client(client),
-      m_manager(new QNetworkAccessManager(this)) {
+      m_manager(networkManager ? networkManager : new QNetworkAccessManager(this)) {
     setWindowTitle(tr("Action Run - %1").arg(n.title));
     resize(700, 500);
 
     setupUi();
 
+    m_requestStatus = new QLabel(this);
+    m_requestStatus->setTextFormat(Qt::PlainText);
+    statusBar()->addWidget(m_requestStatus, 1);
+    m_retryButton = new QPushButton(tr("Retry"), this);
+    statusBar()->addPermanentWidget(m_retryButton);
+    connect(m_retryButton, &QPushButton::clicked, this, &ActionWindow::fetchRunDetails);
     fetchRunDetails();
 }
 
@@ -43,14 +51,24 @@ void ActionWindow::setupUi() {
 }
 
 void ActionWindow::fetchRunDetails() {
+    m_detailsGeneration = QUuid::createUuid();
+    m_requestStatus->setText(tr("Loading action details..."));
+    m_retryButton->setEnabled(false);
     QUrl url(m_notification.url);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
     QNetworkReply* reply = m_manager->get(request);
+    reply->setProperty("generation", m_detailsGeneration);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onRunDetailsReply(reply); });
 }
 
 void ActionWindow::onRunDetailsReply(QNetworkReply* reply) {
+    if (reply->property("generation").toUuid() != m_detailsGeneration) {
+        reply->deleteLater();
+        return;
+    }
+    m_retryButton->setEnabled(true);
     if (reply->error() == QNetworkReply::NoError) {
+        m_requestStatus->setText(tr("Action details loaded."));
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
         QJsonObject obj = doc.object();
@@ -66,7 +84,9 @@ void ActionWindow::onRunDetailsReply(QNetworkReply* reply) {
 
         fetchJobs();
     } else {
-        QMessageBox::warning(this, tr("Error"), tr("Failed to fetch action details: %1").arg(reply->errorString()));
+        m_statusLabel->setText(tr("Action details unavailable."));
+        m_requestStatus->setText(
+            tr("Failed to fetch action details: %1. Retry to try again.").arg(reply->errorString()));
     }
     reply->deleteLater();
 }
@@ -77,10 +97,15 @@ void ActionWindow::fetchJobs() {
     QUrl url(m_jobsUrl);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
     QNetworkReply* reply = m_manager->get(request);
+    reply->setProperty("generation", m_detailsGeneration);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onJobsReply(reply); });
 }
 
 void ActionWindow::onJobsReply(QNetworkReply* reply) {
+    if (reply->property("generation").toUuid() != m_detailsGeneration) {
+        reply->deleteLater();
+        return;
+    }
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);

--- a/src/ActionWindow.h
+++ b/src/ActionWindow.h
@@ -5,6 +5,7 @@
 #include <QLabel>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <QPushButton>
 #include <QTableWidget>
 #include <QTextEdit>
 #include <QVBoxLayout>
@@ -14,9 +15,11 @@
 
 class ActionWindow : public KXmlGuiWindow {
     Q_OBJECT
+    friend class TestRequestConsumers;
 
    public:
-    explicit ActionWindow(const Notification& n, GitHubClient* client, QWidget* parent = nullptr);
+    explicit ActionWindow(const Notification& n, GitHubClient* client, QWidget* parent = nullptr,
+                          QNetworkAccessManager* networkManager = nullptr);
 
    private slots:
     void fetchRunDetails();
@@ -29,6 +32,9 @@ class ActionWindow : public KXmlGuiWindow {
     Notification m_notification;
     GitHubClient* m_client;
     QNetworkAccessManager* m_manager;
+    QUuid m_detailsGeneration;
+    QLabel* m_requestStatus;
+    QPushButton* m_retryButton;
 
     QLabel* m_statusLabel;
     QTableWidget* m_jobsTable;

--- a/src/DebugWindow.cpp
+++ b/src/DebugWindow.cpp
@@ -141,11 +141,13 @@ void DebugWindow::sendRequest() {
 
     m_responseOutput->setText(tr("Loading..."));
     m_sendButton->setEnabled(false);
-    m_currentReqId = m_client->requestRaw(endpoint, method, body);
+    m_currentReqId = QUuid::createUuid();
+    m_client->requestRaw(endpoint, method, body, m_currentReqId);
 }
 
 void DebugWindow::displayResponse(const QUuid& reqId, const QByteArray& data) {
-    if (reqId != m_currentReqId) return;
+    if (reqId.isNull() || reqId != m_currentReqId) return;
+    m_currentReqId = QUuid();
     m_sendButton->setEnabled(true);
     // Only update if we are visible
     // Check if JSON and format it?
@@ -160,7 +162,8 @@ void DebugWindow::displayResponse(const QUuid& reqId, const QByteArray& data) {
 void DebugWindow::setEndpoint(const QString& url) { m_endpointInput->setText(url); }
 
 void DebugWindow::onErrorOccurred(const QUuid& reqId, const QString& error) {
-    if (reqId != m_currentReqId) return;
+    if (reqId.isNull() || reqId != m_currentReqId) return;
+    m_currentReqId = QUuid();
     m_responseOutput->setText(tr("Error: %1").arg(error));
     m_sendButton->setEnabled(true);
 }

--- a/src/DebugWindow.cpp
+++ b/src/DebugWindow.cpp
@@ -68,6 +68,7 @@ DebugWindow::DebugWindow(GitHubClient* client, QWidget* parent) : QDialog(parent
     mainLayout->addWidget(m_responseOutput);
 
     connect(m_client, &GitHubClient::rawDataReceived, this, &DebugWindow::displayResponse);
+    connect(m_client, &GitHubClient::errorOccurred, this, &DebugWindow::onErrorOccurred);
 
     // Trigger initial selection
     onApiSelected(0);
@@ -139,10 +140,13 @@ void DebugWindow::sendRequest() {
     QByteArray body = m_bodyInput->toPlainText().toUtf8();
 
     m_responseOutput->setText(tr("Loading..."));
-    m_client->requestRaw(endpoint, method, body);
+    m_sendButton->setEnabled(false);
+    m_currentReqId = m_client->requestRaw(endpoint, method, body);
 }
 
-void DebugWindow::displayResponse(const QByteArray& data) {
+void DebugWindow::displayResponse(const QUuid& reqId, const QByteArray& data) {
+    if (reqId != m_currentReqId) return;
+    m_sendButton->setEnabled(true);
     // Only update if we are visible
     // Check if JSON and format it?
     QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -154,3 +158,9 @@ void DebugWindow::displayResponse(const QByteArray& data) {
 }
 
 void DebugWindow::setEndpoint(const QString& url) { m_endpointInput->setText(url); }
+
+void DebugWindow::onErrorOccurred(const QUuid& reqId, const QString& error) {
+    if (reqId != m_currentReqId) return;
+    m_responseOutput->setText(tr("Error: %1").arg(error));
+    m_sendButton->setEnabled(true);
+}

--- a/src/DebugWindow.h
+++ b/src/DebugWindow.h
@@ -22,6 +22,8 @@ struct ApiPreset {
 
 class DebugWindow : public QDialog {
     Q_OBJECT
+    friend class TestRequestConsumers;
+
    public:
     explicit DebugWindow(GitHubClient* client, QWidget* parent = nullptr);
     void setEndpoint(const QString& url);

--- a/src/DebugWindow.h
+++ b/src/DebugWindow.h
@@ -28,12 +28,14 @@ class DebugWindow : public QDialog {
 
    private slots:
     void sendRequest();
-    void displayResponse(const QByteArray& data);
+    void displayResponse(const QUuid& reqId, const QByteArray& data);
+    void onErrorOccurred(const QUuid& reqId, const QString& error);
     void onApiSelected(int index);
     void onParamChanged();
 
    private:
     GitHubClient* m_client;
+    QUuid m_currentReqId;
 
     QComboBox* m_apiSelector;
     QComboBox* m_methodSelector;

--- a/src/GitHubClient.cpp
+++ b/src/GitHubClient.cpp
@@ -116,6 +116,7 @@ QUuid GitHubClient::markAsRead(const QString& id, QUuid reqId) {
     QNetworkRequest request = createAuthenticatedRequest(url);
 
     QNetworkReply* reply = manager->sendCustomRequest(request, "PATCH");
+    reply->setProperty("reqId", reqId);
     reply->setProperty("type", "patch");
     return reqId;
 }
@@ -130,6 +131,7 @@ QUuid GitHubClient::markAsDone(const QString& id, QUuid reqId) {
     QNetworkRequest request = createAuthenticatedRequest(url);
 
     QNetworkReply* reply = manager->deleteResource(request);
+    reply->setProperty("reqId", reqId);
     reply->setProperty("type", "delete");
     return reqId;
 }
@@ -144,12 +146,14 @@ QUuid GitHubClient::markAsReadAndDone(const QString& id, QUuid reqId) {
     QNetworkRequest request = createAuthenticatedRequest(url);
 
     QNetworkReply* reply = manager->sendCustomRequest(request, "PATCH");
+    reply->setProperty("reqId", reqId);
     reply->setProperty("type", "read_and_done");
     reply->setProperty("notificationId", id);
     return reqId;
 }
 
 QUuid GitHubClient::fetchNotificationDetails(const QString& url, const QString& notificationId, QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
     if (m_token.isEmpty() || url.isEmpty()) return reqId;
     QUrl qUrl(url);
     if (!qUrl.isValid()) return reqId;
@@ -161,6 +165,7 @@ QUuid GitHubClient::fetchNotificationDetails(const QString& url, const QString& 
 
     QNetworkRequest request = createRequest(qUrl);
     QNetworkReply* reply = manager->get(request);
+    reply->setProperty("reqId", reqId);
     reply->setProperty("type", "details");
     reply->setProperty("notificationId", notificationId);
     return reqId;
@@ -242,6 +247,7 @@ QUuid GitHubClient::fetchUserRepos(const QString& pageUrl, QUuid reqId) {
 
     QNetworkRequest request = createAuthenticatedRequest(url);
     QNetworkReply* reply = manager->get(request);
+    reply->setProperty("reqId", reqId);
     reply->setProperty("type", "repos");
     return reqId;
 }
@@ -327,7 +333,14 @@ void GitHubClient::onReplyFinished(QNetworkReply* reply) {
         if (reply->error() == QNetworkReply::NoError) {
             emit issueCreated(reqId, reply->readAll());
         } else {
-            emit issueCreated(reqId, reply->readAll());
+            QByteArray errorData = reply->readAll();
+            QString errorString = reply->errorString();
+
+            QJsonDocument doc = QJsonDocument::fromJson(errorData);
+            if (doc.isObject() && doc.object().contains("message")) {
+                errorString += " - " + doc.object()["message"].toString();
+            }
+            emit errorOccurred(reqId, errorString);
         }
     } else if (type == "raw") {
         if (reply->error() == QNetworkReply::NoError) {

--- a/src/GitHubClient.cpp
+++ b/src/GitHubClient.cpp
@@ -45,15 +45,19 @@ void GitHubClient::setShowAll(bool all) { m_showAll = all; }
 
 QUuid GitHubClient::checkNotifications(QUuid reqId) {
     if (reqId.isNull()) reqId = QUuid::createUuid();
+    m_notificationSessionId = reqId;
+    m_nextPageUrl.clear();
     emit loadingStarted(reqId);
 
-    if (m_token.isEmpty()) return reqId;
+    if (m_token.isEmpty()) {
+        emit authError(reqId, "No token provided");
+        return reqId;
+    }
 
     QUrl url(m_apiUrl + "/notifications");
     QUrlQuery query;
-    if (m_showAll) {
-        query.addQueryItem("all", "true");
-    }
+    // Include read notifications for client-side filtering.
+    query.addQueryItem("all", "true");
     url.setQuery(query);
 
     QNetworkRequest request = createAuthenticatedRequest(url);
@@ -67,10 +71,17 @@ QUuid GitHubClient::checkNotifications(QUuid reqId) {
 }
 
 QUuid GitHubClient::loadMore(QUuid reqId) {
+    if (reqId.isNull()) reqId = m_notificationSessionId;
     if (reqId.isNull()) reqId = QUuid::createUuid();
-    if (m_nextPageUrl.isEmpty()) return reqId;
-
     emit loadingStarted(reqId);
+    if (reqId != m_notificationSessionId || m_nextPageUrl.isEmpty()) {
+        emit errorOccurred(reqId, "No active notification page to load.");
+        return reqId;
+    }
+    if (m_token.isEmpty()) {
+        emit authError(reqId, "No token provided");
+        return reqId;
+    }
 
     QUrl url(m_nextPageUrl);
 
@@ -108,7 +119,10 @@ QUuid GitHubClient::verifyToken(QUuid reqId) {
 
 QUuid GitHubClient::markAsRead(const QString& id, QUuid reqId) {
     if (reqId.isNull()) reqId = QUuid::createUuid();
-    if (m_token.isEmpty()) return reqId;
+    if (m_token.isEmpty()) {
+        emit errorOccurred(reqId, "No token provided");
+        return reqId;
+    }
 
     m_pendingPatchRequests++;
 
@@ -123,7 +137,10 @@ QUuid GitHubClient::markAsRead(const QString& id, QUuid reqId) {
 
 QUuid GitHubClient::markAsDone(const QString& id, QUuid reqId) {
     if (reqId.isNull()) reqId = QUuid::createUuid();
-    if (m_token.isEmpty()) return reqId;
+    if (m_token.isEmpty()) {
+        emit errorOccurred(reqId, "No token provided");
+        return reqId;
+    }
 
     m_pendingPatchRequests++;
 
@@ -138,7 +155,10 @@ QUuid GitHubClient::markAsDone(const QString& id, QUuid reqId) {
 
 QUuid GitHubClient::markAsReadAndDone(const QString& id, QUuid reqId) {
     if (reqId.isNull()) reqId = QUuid::createUuid();
-    if (m_token.isEmpty()) return reqId;
+    if (m_token.isEmpty()) {
+        emit errorOccurred(reqId, "No token provided");
+        return reqId;
+    }
 
     m_pendingPatchRequests++;
 
@@ -154,11 +174,14 @@ QUuid GitHubClient::markAsReadAndDone(const QString& id, QUuid reqId) {
 
 QUuid GitHubClient::fetchNotificationDetails(const QString& url, const QString& notificationId, QUuid reqId) {
     if (reqId.isNull()) reqId = QUuid::createUuid();
-    if (m_token.isEmpty() || url.isEmpty()) return reqId;
     QUrl qUrl(url);
-    if (!qUrl.isValid()) return reqId;
+    if (m_token.isEmpty() || url.isEmpty() || !qUrl.isValid()) {
+        emit detailsError(reqId, notificationId, m_token.isEmpty() ? "No token provided" : "Invalid details URL");
+        return reqId;
+    }
 
     if (!isTrustedApiOrigin(qUrl)) {
+        emit detailsError(reqId, notificationId, "Untrusted notification details URL rejected.");
         emit errorOccurred(reqId, "Untrusted notification details URL rejected.");
         return reqId;
     }
@@ -173,7 +196,10 @@ QUuid GitHubClient::fetchNotificationDetails(const QString& url, const QString& 
 
 QUuid GitHubClient::fetchImage(const QString& imageUrl, const QString& notificationId, QUuid reqId) {
     if (reqId.isNull()) reqId = QUuid::createUuid();
-    if (imageUrl.isEmpty()) return reqId;
+    if (imageUrl.isEmpty() || !QUrl(imageUrl).isValid()) {
+        emit detailsError(reqId, notificationId, "Invalid image URL");
+        return reqId;
+    }
 
     QUrl url(imageUrl);
     QNetworkRequest request = createRequest(url);
@@ -186,7 +212,10 @@ QUuid GitHubClient::fetchImage(const QString& imageUrl, const QString& notificat
 
 QUuid GitHubClient::requestRaw(const QString& endpoint, const QString& method, const QByteArray& body, QUuid reqId) {
     if (reqId.isNull()) reqId = QUuid::createUuid();
-    if (m_token.isEmpty()) return reqId;
+    if (m_token.isEmpty()) {
+        emit errorOccurred(reqId, "No token provided");
+        return reqId;
+    }
 
     QString urlStr = endpoint;
     if (!urlStr.startsWith("http")) {
@@ -216,6 +245,8 @@ QUuid GitHubClient::requestRaw(const QString& endpoint, const QString& method, c
         reply = manager->put(request, body);
     } else if (method.toUpper() == "DELETE") {
         reply = manager->deleteResource(request);
+    } else {
+        reply = manager->sendCustomRequest(request, method.toUtf8(), body);
     }
 
     if (reply) {
@@ -227,7 +258,10 @@ QUuid GitHubClient::requestRaw(const QString& endpoint, const QString& method, c
 
 QUuid GitHubClient::fetchUserRepos(const QString& pageUrl, QUuid reqId) {
     if (reqId.isNull()) reqId = QUuid::createUuid();
-    if (m_token.isEmpty()) return reqId;
+    if (m_token.isEmpty()) {
+        emit errorOccurred(reqId, "No token provided");
+        return reqId;
+    }
 
     QUrl url;
     if (pageUrl.isEmpty()) {
@@ -252,6 +286,118 @@ QUuid GitHubClient::fetchUserRepos(const QString& pageUrl, QUuid reqId) {
     return reqId;
 }
 
+QUuid GitHubClient::verifyRepo(const QString& repoFullName, QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    if (m_token.isEmpty()) {
+        emit errorOccurred(reqId, "No token provided");
+        return reqId;
+    }
+
+    QUrl url(m_apiUrl + "/repos/" + repoFullName);
+    QNetworkRequest request = createAuthenticatedRequest(url);
+    QNetworkReply* reply = manager->get(request);
+    reply->setProperty("reqId", reqId);
+    reply->setProperty("type", "verifyRepo");
+    reply->setProperty("repoFullName", repoFullName);
+    return reqId;
+}
+
+QUuid GitHubClient::createIssue(const QString& repoFullName, const QString& title, const QString& body,
+                                const QString& assignee, QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    if (m_token.isEmpty()) {
+        emit errorOccurred(reqId, "No token provided");
+        return reqId;
+    }
+
+    QUrl url(m_apiUrl + "/repos/" + repoFullName + "/issues");
+    QNetworkRequest request = createAuthenticatedRequest(url);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+
+    QJsonObject obj;
+    obj["title"] = title;
+    if (!body.isEmpty()) {
+        obj["body"] = body;
+    }
+    if (!assignee.isEmpty()) {
+        QJsonArray assignees;
+        assignees.append(assignee);
+        obj["assignees"] = assignees;
+    }
+
+    QJsonDocument doc(obj);
+    QByteArray postData = doc.toJson(QJsonDocument::Compact);
+
+    QNetworkReply* reply = manager->post(request, postData);
+    reply->setProperty("reqId", reqId);
+    reply->setProperty("type", "createIssue");
+    return reqId;
+}
+
+QNetworkRequest GitHubClient::createAuthenticatedRequest(const QUrl& url) const { return createRequest(url); }
+
+void GitHubClient::onReplyFinished(QNetworkReply* reply) {
+    QString type = reply->property("type").toString();
+    QUuid reqId = reply->property("reqId").toUuid();
+
+    if (type == "details") {
+        handleDetailsReply(reply);
+    } else if (type == "image") {
+        handleImageReply(reply);
+    } else if (type == "verification") {
+        handleVerificationReply(reply);
+    } else if (type == "repos") {
+        handleUserReposReply(reply);
+    } else if (type == "verifyRepo") {
+        handleRepoVerifyReply(reply);
+    } else if (type == "createIssue") {
+        if (reply->error() == QNetworkReply::NoError) {
+            emit issueCreated(reqId, reply->readAll());
+        } else {
+            QByteArray errorData = reply->readAll();
+            QString errorString = reply->errorString();
+
+            QJsonDocument doc = QJsonDocument::fromJson(errorData);
+            if (doc.isObject() && doc.object().contains("message")) {
+                errorString += " - " + doc.object()["message"].toString();
+            }
+            emit errorOccurred(reqId, errorString);
+        }
+    } else if (type == "raw") {
+        if (reply->error() == QNetworkReply::NoError) {
+            emit rawDataReceived(reqId, reply->readAll());
+        } else {
+            emit errorOccurred(reqId, reply->errorString());
+        }
+    } else if (type == "patch" || type == "delete") {
+        handlePatchReply(reply);
+    } else if (type == "read_and_done") {
+        QString id = reply->property("notificationId").toString();
+        m_pendingPatchRequests--;
+        if (m_pendingPatchRequests < 0) m_pendingPatchRequests = 0;
+
+        if (reply->error() == QNetworkReply::NoError) {
+            markAsDone(id, reqId);
+        } else {
+            if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
+                emit authError(reqId, "Invalid Token");
+            } else {
+                emit errorOccurred(reqId, reply->errorString());
+            }
+        }
+
+        if (m_pendingPatchRequests == 0) {
+            emit notificationsChanged();
+        }
+    } else if (type == "notifications") {
+        handleNotificationsReply(reply);
+    } else {
+        qDebug() << "Unknown reply type:" << type;
+    }
+
+    reply->deleteLater();
+}
+
 bool GitHubClient::isTrustedApiOrigin(const QUrl& url) const {
     QUrl apiOrigin(m_apiUrl);
 
@@ -271,8 +417,6 @@ bool GitHubClient::isTrustedApiOrigin(const QUrl& url) const {
 
     return urlPort == apiPort;
 }
-
-QNetworkRequest GitHubClient::createAuthenticatedRequest(const QUrl& url) const { return createRequest(url); }
 
 QNetworkRequest GitHubClient::createRequest(const QUrl& url) const {
     QNetworkRequest request(url);
@@ -310,73 +454,6 @@ QNetworkRequest GitHubClient::createRequest(const QUrl& url) const {
     return request;
 }
 
-void GitHubClient::onReplyFinished(QNetworkReply* reply) {
-    if (reply->error() == QNetworkReply::OperationCanceledError) {
-        reply->deleteLater();
-        return;
-    }
-
-    QString type = reply->property("type").toString();
-    QUuid reqId = reply->property("reqId").toUuid();
-
-    if (type == "details") {
-        handleDetailsReply(reply);
-    } else if (type == "image") {
-        handleImageReply(reply);
-    } else if (type == "verification") {
-        handleVerificationReply(reply);
-    } else if (type == "repos") {
-        handleUserReposReply(reply);
-    } else if (type == "verifyRepo") {
-        handleRepoVerifyReply(reply);
-    } else if (type == "createIssue") {
-        if (reply->error() == QNetworkReply::NoError) {
-            emit issueCreated(reqId, reply->readAll());
-        } else {
-            QByteArray errorData = reply->readAll();
-            QString errorString = reply->errorString();
-
-            QJsonDocument doc = QJsonDocument::fromJson(errorData);
-            if (doc.isObject() && doc.object().contains("message")) {
-                errorString += " - " + doc.object()["message"].toString();
-            }
-            emit errorOccurred(reqId, errorString);
-        }
-    } else if (type == "raw") {
-        if (reply->error() == QNetworkReply::NoError) {
-            emit rawDataReceived(reqId, reply->readAll());
-        } else {
-            emit rawDataReceived(reqId, reply->errorString().toUtf8());
-        }
-    } else if (type == "patch" || type == "delete") {
-        handlePatchReply(reply);
-    } else if (type == "read_and_done") {
-        QString id = reply->property("notificationId").toString();
-        m_pendingPatchRequests--;
-        if (m_pendingPatchRequests < 0) m_pendingPatchRequests = 0;
-
-        if (reply->error() == QNetworkReply::NoError) {
-            markAsDone(id, reqId);
-        } else {
-            if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
-                emit authError(reqId, "Invalid Token");
-            } else {
-                emit errorOccurred(reqId, reply->errorString());
-            }
-        }
-
-        if (m_pendingPatchRequests == 0) {
-            checkNotifications(reqId);
-        }
-    } else if (type == "notifications") {
-        handleNotificationsReply(reply);
-    } else {
-        qDebug() << "Unknown reply type:" << type;
-    }
-
-    reply->deleteLater();
-}
-
 void GitHubClient::handleDetailsReply(QNetworkReply* reply) {
     QString notificationId = reply->property("notificationId").toString();
     QUuid reqId = reply->property("reqId").toUuid();
@@ -406,6 +483,8 @@ void GitHubClient::handleDetailsReply(QNetworkReply* reply) {
         QString htmlUrl = obj["html_url"].toString();
 
         emit detailsReceived(reqId, notificationId, authorName, avatarUrl, htmlUrl);
+    } else {
+        emit detailsError(reqId, notificationId, "Invalid details response");
     }
 }
 
@@ -413,7 +492,7 @@ void GitHubClient::handleImageReply(QNetworkReply* reply) {
     QString notificationId = reply->property("notificationId").toString();
     QUuid reqId = reply->property("reqId").toUuid();
     if (reply->error() != QNetworkReply::NoError) {
-        qDebug() << "Error fetching image:" << reply->errorString();
+        emit detailsError(reqId, notificationId, reply->errorString());
         return;
     }
 
@@ -421,6 +500,8 @@ void GitHubClient::handleImageReply(QNetworkReply* reply) {
     QPixmap pixmap;
     if (pixmap.loadFromData(data)) {
         emit imageReceived(reqId, notificationId, pixmap);
+    } else {
+        emit detailsError(reqId, notificationId, "Invalid image response");
     }
 }
 
@@ -499,13 +580,15 @@ void GitHubClient::handlePatchReply(QNetworkReply* reply) {
         return;
     }
 
+    emit mutationSucceeded(reqId);
     if (m_pendingPatchRequests == 0) {
-        checkNotifications(reqId);
+        emit notificationsChanged();
     }
 }
 
 void GitHubClient::handleNotificationsReply(QNetworkReply* reply) {
     QUuid reqId = reply->property("reqId").toUuid();
+    if (reqId != m_notificationSessionId) return;
     if (reply->error() != QNetworkReply::NoError) {
         if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
             emit authError(reqId, "Invalid Token");
@@ -592,54 +675,14 @@ void GitHubClient::handleNotificationsReply(QNetworkReply* reply) {
     }
 }
 
-QUuid GitHubClient::verifyRepo(const QString& repoFullName, QUuid reqId) {
-    if (reqId.isNull()) reqId = QUuid::createUuid();
-    if (m_token.isEmpty()) return reqId;
-
-    QUrl url(m_apiUrl + "/repos/" + repoFullName);
-    QNetworkRequest request = createAuthenticatedRequest(url);
-    QNetworkReply* reply = manager->get(request);
-    reply->setProperty("reqId", reqId);
-    reply->setProperty("type", "verifyRepo");
-    reply->setProperty("repoFullName", repoFullName);
-    return reqId;
-}
-
 void GitHubClient::handleRepoVerifyReply(QNetworkReply* reply) {
     QUuid reqId = reply->property("reqId").toUuid();
     QString repoFullName = reply->property("repoFullName").toString();
     if (reply->error() == QNetworkReply::NoError) {
         emit repoVerified(reqId, repoFullName, true);
-    } else {
+    } else if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 404) {
         emit repoVerified(reqId, repoFullName, false);
+    } else {
+        emit errorOccurred(reqId, reply->errorString());
     }
-}
-
-QUuid GitHubClient::createIssue(const QString& repoFullName, const QString& title, const QString& body,
-                                const QString& assignee, QUuid reqId) {
-    if (reqId.isNull()) reqId = QUuid::createUuid();
-    if (m_token.isEmpty()) return reqId;
-
-    QUrl url(m_apiUrl + "/repos/" + repoFullName + "/issues");
-    QNetworkRequest request = createAuthenticatedRequest(url);
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-
-    QJsonObject obj;
-    obj["title"] = title;
-    if (!body.isEmpty()) {
-        obj["body"] = body;
-    }
-    if (!assignee.isEmpty()) {
-        QJsonArray assignees;
-        assignees.append(assignee);
-        obj["assignees"] = assignees;
-    }
-
-    QJsonDocument doc(obj);
-    QByteArray postData = doc.toJson(QJsonDocument::Compact);
-
-    QNetworkReply* reply = manager->post(request, postData);
-    reply->setProperty("reqId", reqId);
-    reply->setProperty("type", "createIssue");
-    return reqId;
 }

--- a/src/GitHubClient.cpp
+++ b/src/GitHubClient.cpp
@@ -19,8 +19,7 @@ GitHubClient::GitHubClient(QObject* parent) : QObject(parent) {
     m_pendingPatchRequests = 0;
     m_showAll = false;
     m_nextPageUrl = "";
-
-    }
+}
 
 QString GitHubClient::apiToHtmlUrl(const QString& apiUrl, const QString& notificationId) {
     QString htmlUrl = apiUrl;
@@ -604,7 +603,7 @@ void GitHubClient::handleRepoVerifyReply(QNetworkReply* reply) {
 }
 
 QUuid GitHubClient::createIssue(const QString& repoFullName, const QString& title, const QString& body,
-                               const QString& assignee, QUuid reqId) {
+                                const QString& assignee, QUuid reqId) {
     if (reqId.isNull()) reqId = QUuid::createUuid();
     if (m_token.isEmpty()) return reqId;
 

--- a/src/GitHubClient.cpp
+++ b/src/GitHubClient.cpp
@@ -20,10 +20,7 @@ GitHubClient::GitHubClient(QObject* parent) : QObject(parent) {
     m_showAll = false;
     m_nextPageUrl = "";
 
-    m_requestTimeoutTimer = new QTimer(this);
-    m_requestTimeoutTimer->setSingleShot(true);
-    connect(m_requestTimeoutTimer, &QTimer::timeout, this, &GitHubClient::onRequestTimeout);
-}
+    }
 
 QString GitHubClient::apiToHtmlUrl(const QString& apiUrl, const QString& notificationId) {
     QString htmlUrl = apiUrl;
@@ -47,81 +44,72 @@ void GitHubClient::setApiUrl(const QString& url) { m_apiUrl = url; }
 
 void GitHubClient::setShowAll(bool all) { m_showAll = all; }
 
-void GitHubClient::checkNotifications() {
-    emit loadingStarted();
+QUuid GitHubClient::checkNotifications(QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    emit loadingStarted(reqId);
 
-    m_nextPageUrl.clear();
-
-    if (m_token.isEmpty()) {
-        emit authError("No token provided");
-        return;
-    }
+    if (m_token.isEmpty()) return reqId;
 
     QUrl url(m_apiUrl + "/notifications");
-    // Always fetch all notifications (including read ones) to support client-side filtering
     QUrlQuery query;
-    query.addQueryItem("all", "true");
+    if (m_showAll) {
+        query.addQueryItem("all", "true");
+    }
     url.setQuery(query);
 
     QNetworkRequest request = createAuthenticatedRequest(url);
 
-    if (m_activeNotificationReply) {
-        m_activeNotificationReply->abort();
-    }
-
     QNetworkReply* reply = manager->get(request);
+    reply->setProperty("reqId", reqId);
     reply->setProperty("type", "notifications");
     reply->setProperty("append", false);
-    m_activeNotificationReply = reply;
-
-    m_requestTimeoutTimer->start(30000);  // 30 seconds timeout
+    m_nextPageUrl.clear();
+    return reqId;
 }
 
-void GitHubClient::loadMore() {
-    if (m_nextPageUrl.isEmpty()) return;
+QUuid GitHubClient::loadMore(QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    if (m_nextPageUrl.isEmpty()) return reqId;
 
-    emit loadingStarted();
-
-    if (m_activeNotificationReply) {
-        m_activeNotificationReply->abort();
-    }
+    emit loadingStarted(reqId);
 
     QUrl url(m_nextPageUrl);
 
     if (!isTrustedApiOrigin(url)) {
         m_nextPageUrl.clear();
-        // Signal completion with empty data and no more pages before emitting error
-        // so completion handlers do not overwrite the error status
-        emit notificationsReceived(QList<Notification>(), true, false);
-        emit errorOccurred("Untrusted pagination URL rejected.");
-        return;
+        emit notificationsReceived(reqId, QList<Notification>(), true, false);
+        emit errorOccurred(reqId, "Untrusted pagination URL rejected.");
+        return reqId;
     }
 
     QNetworkRequest request = createAuthenticatedRequest(url);
 
     QNetworkReply* reply = manager->get(request);
+    reply->setProperty("reqId", reqId);
     reply->setProperty("type", "notifications");
     reply->setProperty("append", true);
-    m_activeNotificationReply = reply;
-
-    m_requestTimeoutTimer->start(30000);  // 30 seconds timeout
+    return reqId;
 }
 
-void GitHubClient::verifyToken() {
+QUuid GitHubClient::verifyToken(QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
     if (m_token.isEmpty()) {
-        emit tokenVerified(false, "No token provided");
-        return;
+        emit tokenVerified(reqId, false, "No token provided");
+        return reqId;
     }
 
     QUrl url(m_apiUrl + "/user");
     QNetworkRequest request = createAuthenticatedRequest(url);
 
     QNetworkReply* reply = manager->get(request);
+    reply->setProperty("reqId", reqId);
     reply->setProperty("type", "verification");
+    return reqId;
 }
 
-void GitHubClient::markAsRead(const QString& id) {
-    if (m_token.isEmpty()) return;
+QUuid GitHubClient::markAsRead(const QString& id, QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    if (m_token.isEmpty()) return reqId;
 
     m_pendingPatchRequests++;
 
@@ -130,10 +118,12 @@ void GitHubClient::markAsRead(const QString& id) {
 
     QNetworkReply* reply = manager->sendCustomRequest(request, "PATCH");
     reply->setProperty("type", "patch");
+    return reqId;
 }
 
-void GitHubClient::markAsDone(const QString& id) {
-    if (m_token.isEmpty()) return;
+QUuid GitHubClient::markAsDone(const QString& id, QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    if (m_token.isEmpty()) return reqId;
 
     m_pendingPatchRequests++;
 
@@ -142,10 +132,12 @@ void GitHubClient::markAsDone(const QString& id) {
 
     QNetworkReply* reply = manager->deleteResource(request);
     reply->setProperty("type", "delete");
+    return reqId;
 }
 
-void GitHubClient::markAsReadAndDone(const QString& id) {
-    if (m_token.isEmpty()) return;
+QUuid GitHubClient::markAsReadAndDone(const QString& id, QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    if (m_token.isEmpty()) return reqId;
 
     m_pendingPatchRequests++;
 
@@ -155,74 +147,83 @@ void GitHubClient::markAsReadAndDone(const QString& id) {
     QNetworkReply* reply = manager->sendCustomRequest(request, "PATCH");
     reply->setProperty("type", "read_and_done");
     reply->setProperty("notificationId", id);
+    return reqId;
 }
 
-void GitHubClient::fetchNotificationDetails(const QString& url, const QString& notificationId) {
-    if (m_token.isEmpty() || url.isEmpty()) return;
+QUuid GitHubClient::fetchNotificationDetails(const QString& url, const QString& notificationId, QUuid reqId) {
+    if (m_token.isEmpty() || url.isEmpty()) return reqId;
     QUrl qUrl(url);
-    if (!qUrl.isValid()) return;
+    if (!qUrl.isValid()) return reqId;
 
     if (!isTrustedApiOrigin(qUrl)) {
-        emit errorOccurred("Untrusted notification details URL rejected.");
-        return;
+        emit errorOccurred(reqId, "Untrusted notification details URL rejected.");
+        return reqId;
     }
 
     QNetworkRequest request = createRequest(qUrl);
     QNetworkReply* reply = manager->get(request);
     reply->setProperty("type", "details");
     reply->setProperty("notificationId", notificationId);
+    return reqId;
 }
 
-void GitHubClient::fetchImage(const QString& imageUrl, const QString& notificationId) {
-    QUrl qUrl(imageUrl);
-    QNetworkRequest request(qUrl);
-    // Images (avatars) are usually public, so no auth header needed.
-    // Also, User-Agent is good practice.
-    request.setRawHeader("User-Agent", "Kgithub-notify");
+QUuid GitHubClient::fetchImage(const QString& imageUrl, const QString& notificationId, QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    if (imageUrl.isEmpty()) return reqId;
 
+    QUrl url(imageUrl);
+    QNetworkRequest request = createRequest(url);
     QNetworkReply* reply = manager->get(request);
+    reply->setProperty("reqId", reqId);
     reply->setProperty("type", "image");
     reply->setProperty("notificationId", notificationId);
+    return reqId;
 }
 
-void GitHubClient::requestRaw(const QString& endpoint, const QString& method, const QByteArray& body) {
-    if (m_token.isEmpty()) return;
-    QString urlStr = endpoint.startsWith("http") ? endpoint : m_apiUrl + endpoint;
-    QUrl url(urlStr);
+QUuid GitHubClient::requestRaw(const QString& endpoint, const QString& method, const QByteArray& body, QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    if (m_token.isEmpty()) return reqId;
 
+    QString urlStr = endpoint;
+    if (!urlStr.startsWith("http")) {
+        if (!urlStr.startsWith("/")) urlStr = "/" + urlStr;
+        urlStr = m_apiUrl + urlStr;
+    }
+
+    QUrl url(urlStr);
     if (!isTrustedApiOrigin(url)) {
-        emit rawDataReceived("Error: Untrusted external destination for authenticated request.");
-        return;
+        emit rawDataReceived(reqId, "Error: Untrusted external destination for authenticated request.");
+        return reqId;
     }
 
     QNetworkRequest request = createAuthenticatedRequest(url);
-
-    if (!body.isEmpty()) {
-        request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    }
-
     QNetworkReply* reply = nullptr;
-    QString m = method.toUpper();
 
-    if (m == "GET") {
+    if (method.toUpper() == "GET") {
         reply = manager->get(request);
-    } else if (m == "POST") {
+    } else if (method.toUpper() == "POST") {
+        request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
         reply = manager->post(request, body);
-    } else if (m == "PUT") {
+    } else if (method.toUpper() == "PATCH") {
+        request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+        reply = manager->sendCustomRequest(request, "PATCH", body);
+    } else if (method.toUpper() == "PUT") {
+        request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
         reply = manager->put(request, body);
-    } else if (m == "DELETE") {
+    } else if (method.toUpper() == "DELETE") {
         reply = manager->deleteResource(request);
-    } else {
-        reply = manager->sendCustomRequest(request, method.toUtf8(), body);
     }
 
     if (reply) {
+        reply->setProperty("reqId", reqId);
         reply->setProperty("type", "raw");
     }
+    return reqId;
 }
 
-void GitHubClient::fetchUserRepos(const QString& pageUrl) {
-    if (m_token.isEmpty()) return;
+QUuid GitHubClient::fetchUserRepos(const QString& pageUrl, QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    if (m_token.isEmpty()) return reqId;
 
     QUrl url;
     if (pageUrl.isEmpty()) {
@@ -236,13 +237,14 @@ void GitHubClient::fetchUserRepos(const QString& pageUrl) {
     }
 
     if (!isTrustedApiOrigin(url)) {
-        emit errorOccurred("Untrusted repository pagination URL rejected.");
-        return;
+        emit errorOccurred(reqId, "Untrusted repository pagination URL rejected.");
+        return reqId;
     }
 
     QNetworkRequest request = createAuthenticatedRequest(url);
     QNetworkReply* reply = manager->get(request);
     reply->setProperty("type", "repos");
+    return reqId;
 }
 
 bool GitHubClient::isTrustedApiOrigin(const QUrl& url) const {
@@ -269,6 +271,7 @@ QNetworkRequest GitHubClient::createAuthenticatedRequest(const QUrl& url) const 
 
 QNetworkRequest GitHubClient::createRequest(const QUrl& url) const {
     QNetworkRequest request(url);
+    request.setTransferTimeout(30000);
 
     if (isTrustedApiOrigin(url)) {
         // Add Authorization header only for trusted origins
@@ -303,17 +306,13 @@ QNetworkRequest GitHubClient::createRequest(const QUrl& url) const {
 }
 
 void GitHubClient::onReplyFinished(QNetworkReply* reply) {
-    if (reply == m_activeNotificationReply) {
-        m_requestTimeoutTimer->stop();
-        m_activeNotificationReply = nullptr;
-    }
-
     if (reply->error() == QNetworkReply::OperationCanceledError) {
         reply->deleteLater();
         return;
     }
 
     QString type = reply->property("type").toString();
+    QUuid reqId = reply->property("reqId").toUuid();
 
     if (type == "details") {
         handleDetailsReply(reply);
@@ -327,15 +326,15 @@ void GitHubClient::onReplyFinished(QNetworkReply* reply) {
         handleRepoVerifyReply(reply);
     } else if (type == "createIssue") {
         if (reply->error() == QNetworkReply::NoError) {
-            emit issueCreated(reply->readAll());
+            emit issueCreated(reqId, reply->readAll());
         } else {
-            emit errorOccurred(reply->errorString());
+            emit issueCreated(reqId, reply->readAll());
         }
     } else if (type == "raw") {
         if (reply->error() == QNetworkReply::NoError) {
-            emit rawDataReceived(reply->readAll());
+            emit rawDataReceived(reqId, reply->readAll());
         } else {
-            emit rawDataReceived(reply->errorString().toUtf8());
+            emit rawDataReceived(reqId, reply->errorString().toUtf8());
         }
     } else if (type == "patch" || type == "delete") {
         handlePatchReply(reply);
@@ -345,17 +344,17 @@ void GitHubClient::onReplyFinished(QNetworkReply* reply) {
         if (m_pendingPatchRequests < 0) m_pendingPatchRequests = 0;
 
         if (reply->error() == QNetworkReply::NoError) {
-            markAsDone(id);
+            markAsDone(id, reqId);
         } else {
             if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
-                emit authError("Invalid Token");
+                emit authError(reqId, "Invalid Token");
             } else {
-                emit errorOccurred(reply->errorString());
+                emit errorOccurred(reqId, reply->errorString());
             }
         }
 
         if (m_pendingPatchRequests == 0) {
-            checkNotifications();
+            checkNotifications(reqId);
         }
     } else if (type == "notifications") {
         handleNotificationsReply(reply);
@@ -368,9 +367,10 @@ void GitHubClient::onReplyFinished(QNetworkReply* reply) {
 
 void GitHubClient::handleDetailsReply(QNetworkReply* reply) {
     QString notificationId = reply->property("notificationId").toString();
+    QUuid reqId = reply->property("reqId").toUuid();
     if (reply->error() != QNetworkReply::NoError) {
         qDebug() << "Error fetching details:" << reply->errorString();
-        emit detailsError(notificationId, reply->errorString());
+        emit detailsError(reqId, notificationId, reply->errorString());
         return;
     }
 
@@ -393,12 +393,13 @@ void GitHubClient::handleDetailsReply(QNetworkReply* reply) {
 
         QString htmlUrl = obj["html_url"].toString();
 
-        emit detailsReceived(notificationId, authorName, avatarUrl, htmlUrl);
+        emit detailsReceived(reqId, notificationId, authorName, avatarUrl, htmlUrl);
     }
 }
 
 void GitHubClient::handleImageReply(QNetworkReply* reply) {
     QString notificationId = reply->property("notificationId").toString();
+    QUuid reqId = reply->property("reqId").toUuid();
     if (reply->error() != QNetworkReply::NoError) {
         qDebug() << "Error fetching image:" << reply->errorString();
         return;
@@ -407,34 +408,36 @@ void GitHubClient::handleImageReply(QNetworkReply* reply) {
     QByteArray data = reply->readAll();
     QPixmap pixmap;
     if (pixmap.loadFromData(data)) {
-        emit imageReceived(notificationId, pixmap);
+        emit imageReceived(reqId, notificationId, pixmap);
     }
 }
 
 void GitHubClient::handleVerificationReply(QNetworkReply* reply) {
+    QUuid reqId = reply->property("reqId").toUuid();
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
         if (doc.isObject()) {
             QJsonObject obj = doc.object();
             QString login = obj["login"].toString();
-            emit tokenVerified(true, "Token valid for user: " + login);
+            emit tokenVerified(reqId, true, "Token valid for user: " + login);
         } else {
-            emit tokenVerified(true, "Token valid");
+            emit tokenVerified(reqId, true, "Token valid");
         }
     } else if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
-        emit tokenVerified(false, "Invalid Token");
+        emit tokenVerified(reqId, false, "Invalid Token");
     } else {
-        emit tokenVerified(false, reply->errorString());
+        emit tokenVerified(reqId, false, reply->errorString());
     }
 }
 
 void GitHubClient::handleUserReposReply(QNetworkReply* reply) {
+    QUuid reqId = reply->property("reqId").toUuid();
     if (reply->error() != QNetworkReply::NoError) {
         if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
-            emit authError("Invalid Token");
+            emit authError(reqId, "Invalid Token");
         } else {
-            emit errorOccurred(reply->errorString());
+            emit errorOccurred(reqId, reply->errorString());
         }
         return;
     }
@@ -443,7 +446,7 @@ void GitHubClient::handleUserReposReply(QNetworkReply* reply) {
     QJsonDocument doc = QJsonDocument::fromJson(data);
 
     if (!doc.isArray()) {
-        emit errorOccurred("Invalid JSON response (expected array)");
+        emit errorOccurred(reqId, "Invalid JSON response (expected array)");
         return;
     }
 
@@ -462,13 +465,14 @@ void GitHubClient::handleUserReposReply(QNetworkReply* reply) {
         }
     }
 
-    emit userReposReceived(doc.array(), nextPageUrl);
+    emit userReposReceived(reqId, doc.array(), nextPageUrl);
     if (linkRejected) {
-        emit errorOccurred("Untrusted repository pagination URL rejected.");
+        emit errorOccurred(reqId, "Untrusted repository pagination URL rejected.");
     }
 }
 
 void GitHubClient::handlePatchReply(QNetworkReply* reply) {
+    QUuid reqId = reply->property("reqId").toUuid();
     m_pendingPatchRequests--;
     if (m_pendingPatchRequests < 0) {
         m_pendingPatchRequests = 0;
@@ -476,24 +480,25 @@ void GitHubClient::handlePatchReply(QNetworkReply* reply) {
 
     if (reply->error() != QNetworkReply::NoError) {
         if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
-            emit authError("Invalid Token");
+            emit authError(reqId, "Invalid Token");
         } else {
-            emit errorOccurred(reply->errorString());
+            emit errorOccurred(reqId, reply->errorString());
         }
         return;
     }
 
     if (m_pendingPatchRequests == 0) {
-        checkNotifications();
+        checkNotifications(reqId);
     }
 }
 
 void GitHubClient::handleNotificationsReply(QNetworkReply* reply) {
+    QUuid reqId = reply->property("reqId").toUuid();
     if (reply->error() != QNetworkReply::NoError) {
         if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
-            emit authError("Invalid Token");
+            emit authError(reqId, "Invalid Token");
         } else {
-            emit errorOccurred(reply->errorString());
+            emit errorOccurred(reqId, reply->errorString());
         }
         return;
     }
@@ -502,7 +507,7 @@ void GitHubClient::handleNotificationsReply(QNetworkReply* reply) {
     QJsonDocument doc = QJsonDocument::fromJson(data);
 
     if (!doc.isArray()) {
-        emit errorOccurred("Invalid JSON response (expected array)");
+        emit errorOccurred(reqId, "Invalid JSON response (expected array)");
         return;
     }
 
@@ -569,41 +574,39 @@ void GitHubClient::handleNotificationsReply(QNetworkReply* reply) {
     }
 
     bool append = reply->property("append").toBool();
-    emit notificationsReceived(notifications, append, !m_nextPageUrl.isEmpty());
+    emit notificationsReceived(reqId, notifications, append, !m_nextPageUrl.isEmpty());
     if (linkRejected) {
-        emit errorOccurred("Untrusted pagination URL rejected.");
+        emit errorOccurred(reqId, "Untrusted pagination URL rejected.");
     }
 }
 
-void GitHubClient::onRequestTimeout() {
-    emit errorOccurred("Request timed out");
-    if (m_activeNotificationReply) {
-        m_activeNotificationReply->abort();
-    }
-}
-
-void GitHubClient::verifyRepo(const QString& repoFullName) {
-    if (m_token.isEmpty()) return;
+QUuid GitHubClient::verifyRepo(const QString& repoFullName, QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    if (m_token.isEmpty()) return reqId;
 
     QUrl url(m_apiUrl + "/repos/" + repoFullName);
     QNetworkRequest request = createAuthenticatedRequest(url);
     QNetworkReply* reply = manager->get(request);
+    reply->setProperty("reqId", reqId);
     reply->setProperty("type", "verifyRepo");
     reply->setProperty("repoFullName", repoFullName);
+    return reqId;
 }
 
 void GitHubClient::handleRepoVerifyReply(QNetworkReply* reply) {
+    QUuid reqId = reply->property("reqId").toUuid();
     QString repoFullName = reply->property("repoFullName").toString();
     if (reply->error() == QNetworkReply::NoError) {
-        emit repoVerified(repoFullName, true);
+        emit repoVerified(reqId, repoFullName, true);
     } else {
-        emit repoVerified(repoFullName, false);
+        emit repoVerified(reqId, repoFullName, false);
     }
 }
 
-void GitHubClient::createIssue(const QString& repoFullName, const QString& title, const QString& body,
-                               const QString& assignee) {
-    if (m_token.isEmpty()) return;
+QUuid GitHubClient::createIssue(const QString& repoFullName, const QString& title, const QString& body,
+                               const QString& assignee, QUuid reqId) {
+    if (reqId.isNull()) reqId = QUuid::createUuid();
+    if (m_token.isEmpty()) return reqId;
 
     QUrl url(m_apiUrl + "/repos/" + repoFullName + "/issues");
     QNetworkRequest request = createAuthenticatedRequest(url);
@@ -624,5 +627,7 @@ void GitHubClient::createIssue(const QString& repoFullName, const QString& title
     QByteArray postData = doc.toJson(QJsonDocument::Compact);
 
     QNetworkReply* reply = manager->post(request, postData);
+    reply->setProperty("reqId", reqId);
     reply->setProperty("type", "createIssue");
+    return reqId;
 }

--- a/src/GitHubClient.h
+++ b/src/GitHubClient.h
@@ -8,9 +8,8 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QObject>
-
-#include <QUuid>
 #include <QTimer>
+#include <QUuid>
 
 #include "Notification.h"
 #include "SecureString.h"
@@ -33,18 +32,19 @@ class GitHubClient : public QObject {
     QUuid markAsReadAndDone(const QString& id, QUuid reqId = QUuid());
     QUuid fetchNotificationDetails(const QString& url, const QString& notificationId, QUuid reqId = QUuid());
     QUuid fetchImage(const QString& imageUrl, const QString& notificationId, QUuid reqId = QUuid());
-    QUuid requestRaw(const QString& endpoint, const QString& method = "GET", const QByteArray& body = QByteArray(), QUuid reqId = QUuid());
+    QUuid requestRaw(const QString& endpoint, const QString& method = "GET", const QByteArray& body = QByteArray(),
+                     QUuid reqId = QUuid());
     QUuid fetchUserRepos(const QString& pageUrl = QString(), QUuid reqId = QUuid());
     QUuid verifyRepo(const QString& repoFullName, QUuid reqId = QUuid());
     QUuid createIssue(const QString& repoFullName, const QString& title, const QString& body,
-                     const QString& assignee = "", QUuid reqId = QUuid());
+                      const QString& assignee = "", QUuid reqId = QUuid());
     QNetworkRequest createAuthenticatedRequest(const QUrl& url) const;
 
    signals:
     void loadingStarted(const QUuid& reqId);
     void notificationsReceived(const QUuid& reqId, const QList<Notification>& notifications, bool append, bool hasMore);
-    void detailsReceived(const QUuid& reqId, const QString& notificationId, const QString& authorName, const QString& avatarUrl,
-                         const QString& htmlUrl);
+    void detailsReceived(const QUuid& reqId, const QString& notificationId, const QString& authorName,
+                         const QString& avatarUrl, const QString& htmlUrl);
     void detailsError(const QUuid& reqId, const QString& notificationId, const QString& error);
     void imageReceived(const QUuid& reqId, const QString& notificationId, const QPixmap& avatar);
     void rawDataReceived(const QUuid& reqId, const QByteArray& data);
@@ -65,7 +65,6 @@ class GitHubClient : public QObject {
     bool m_showAll;
     int m_pendingPatchRequests;
     QString m_nextPageUrl;
-
 
     bool isTrustedApiOrigin(const QUrl& url) const;
     QNetworkRequest createRequest(const QUrl& url) const;

--- a/src/GitHubClient.h
+++ b/src/GitHubClient.h
@@ -8,7 +8,8 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QObject>
-#include <QPointer>
+
+#include <QUuid>
 #include <QTimer>
 
 #include "Notification.h"
@@ -24,39 +25,38 @@ class GitHubClient : public QObject {
     void setToken(const QString& token);
     void setApiUrl(const QString& url);
     void setShowAll(bool all);
-    void checkNotifications();
-    void loadMore();
-    void verifyToken();
-    void markAsRead(const QString& id);
-    void markAsDone(const QString& id);
-    void markAsReadAndDone(const QString& id);
-    void fetchNotificationDetails(const QString& url, const QString& notificationId);
-    void fetchImage(const QString& imageUrl, const QString& notificationId);
-    void requestRaw(const QString& endpoint, const QString& method = "GET", const QByteArray& body = QByteArray());
-    void fetchUserRepos(const QString& pageUrl = QString());
-    void verifyRepo(const QString& repoFullName);
-    void createIssue(const QString& repoFullName, const QString& title, const QString& body,
-                     const QString& assignee = "");
+    QUuid checkNotifications(QUuid reqId = QUuid());
+    QUuid loadMore(QUuid reqId = QUuid());
+    QUuid verifyToken(QUuid reqId = QUuid());
+    QUuid markAsRead(const QString& id, QUuid reqId = QUuid());
+    QUuid markAsDone(const QString& id, QUuid reqId = QUuid());
+    QUuid markAsReadAndDone(const QString& id, QUuid reqId = QUuid());
+    QUuid fetchNotificationDetails(const QString& url, const QString& notificationId, QUuid reqId = QUuid());
+    QUuid fetchImage(const QString& imageUrl, const QString& notificationId, QUuid reqId = QUuid());
+    QUuid requestRaw(const QString& endpoint, const QString& method = "GET", const QByteArray& body = QByteArray(), QUuid reqId = QUuid());
+    QUuid fetchUserRepos(const QString& pageUrl = QString(), QUuid reqId = QUuid());
+    QUuid verifyRepo(const QString& repoFullName, QUuid reqId = QUuid());
+    QUuid createIssue(const QString& repoFullName, const QString& title, const QString& body,
+                     const QString& assignee = "", QUuid reqId = QUuid());
     QNetworkRequest createAuthenticatedRequest(const QUrl& url) const;
 
    signals:
-    void loadingStarted();
-    void notificationsReceived(const QList<Notification>& notifications, bool append, bool hasMore);
-    void detailsReceived(const QString& notificationId, const QString& authorName, const QString& avatarUrl,
+    void loadingStarted(const QUuid& reqId);
+    void notificationsReceived(const QUuid& reqId, const QList<Notification>& notifications, bool append, bool hasMore);
+    void detailsReceived(const QUuid& reqId, const QString& notificationId, const QString& authorName, const QString& avatarUrl,
                          const QString& htmlUrl);
-    void detailsError(const QString& notificationId, const QString& error);
-    void imageReceived(const QString& notificationId, const QPixmap& avatar);
-    void rawDataReceived(const QByteArray& data);
-    void userReposReceived(const QJsonArray& repos, const QString& nextPageUrl);
-    void errorOccurred(const QString& error);
-    void authError(const QString& message);
-    void tokenVerified(bool valid, const QString& message);
-    void repoVerified(const QString& repoFullName, bool exists);
-    void issueCreated(const QByteArray& data);
+    void detailsError(const QUuid& reqId, const QString& notificationId, const QString& error);
+    void imageReceived(const QUuid& reqId, const QString& notificationId, const QPixmap& avatar);
+    void rawDataReceived(const QUuid& reqId, const QByteArray& data);
+    void userReposReceived(const QUuid& reqId, const QJsonArray& repos, const QString& nextPageUrl);
+    void errorOccurred(const QUuid& reqId, const QString& error);
+    void authError(const QUuid& reqId, const QString& message);
+    void tokenVerified(const QUuid& reqId, bool valid, const QString& message);
+    void repoVerified(const QUuid& reqId, const QString& repoFullName, bool exists);
+    void issueCreated(const QUuid& reqId, const QByteArray& data);
 
    private slots:
     void onReplyFinished(QNetworkReply* reply);
-    void onRequestTimeout();
 
    private:
     QNetworkAccessManager* manager;
@@ -65,8 +65,7 @@ class GitHubClient : public QObject {
     bool m_showAll;
     int m_pendingPatchRequests;
     QString m_nextPageUrl;
-    QPointer<QNetworkReply> m_activeNotificationReply;
-    QTimer* m_requestTimeoutTimer;
+
 
     bool isTrustedApiOrigin(const QUrl& url) const;
     QNetworkRequest createRequest(const QUrl& url) const;

--- a/src/GitHubClient.h
+++ b/src/GitHubClient.h
@@ -25,6 +25,7 @@ class GitHubClient : public QObject {
     void setApiUrl(const QString& url);
     void setShowAll(bool all);
     QUuid checkNotifications(QUuid reqId = QUuid());
+    QUuid checkNotificationsWithUrl(const QUrl& url, QUuid reqId = QUuid());
     QUuid loadMore(QUuid reqId = QUuid());
     QUuid verifyToken(QUuid reqId = QUuid());
     QUuid markAsRead(const QString& id, QUuid reqId = QUuid());

--- a/src/GitHubClient.h
+++ b/src/GitHubClient.h
@@ -8,7 +8,6 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QObject>
-#include <QTimer>
 #include <QUuid>
 
 #include "Notification.h"
@@ -16,16 +15,17 @@
 
 class GitHubClient : public QObject {
     Q_OBJECT
+    friend class TestRequestConsumers;
     friend class TestGitHubClient;
 
    public:
+    // Construction and request dispatch
     explicit GitHubClient(QObject* parent = nullptr);
     static QString apiToHtmlUrl(const QString& apiUrl, const QString& notificationId = "");
     void setToken(const QString& token);
     void setApiUrl(const QString& url);
     void setShowAll(bool all);
     QUuid checkNotifications(QUuid reqId = QUuid());
-    QUuid checkNotificationsWithUrl(const QUrl& url, QUuid reqId = QUuid());
     QUuid loadMore(QUuid reqId = QUuid());
     QUuid verifyToken(QUuid reqId = QUuid());
     QUuid markAsRead(const QString& id, QUuid reqId = QUuid());
@@ -42,6 +42,9 @@ class GitHubClient : public QObject {
     QNetworkRequest createAuthenticatedRequest(const QUrl& url) const;
 
    signals:
+    // Request-scoped results
+    void mutationSucceeded(const QUuid& reqId);
+    void notificationsChanged();
     void loadingStarted(const QUuid& reqId);
     void notificationsReceived(const QUuid& reqId, const QList<Notification>& notifications, bool append, bool hasMore);
     void detailsReceived(const QUuid& reqId, const QString& notificationId, const QString& authorName,
@@ -60,13 +63,16 @@ class GitHubClient : public QObject {
     void onReplyFinished(QNetworkReply* reply);
 
    private:
+    // Network and notification session state
     QNetworkAccessManager* manager;
     SecureString m_token;
     QString m_apiUrl;
     bool m_showAll;
     int m_pendingPatchRequests;
     QString m_nextPageUrl;
+    QUuid m_notificationSessionId;
 
+    // Request construction and reply handling
     bool isTrustedApiOrigin(const QUrl& url) const;
     QNetworkRequest createRequest(const QUrl& url) const;
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -95,6 +95,7 @@ MainWindow::~MainWindow() {
 
 void MainWindow::setClient(GitHubClient* c) {
     client = c;
+    connect(client, &GitHubClient::notificationsChanged, this, &MainWindow::onRefreshClicked);
     connect(client, &GitHubClient::loadingStarted, this, &MainWindow::onLoadingStarted);
     connect(client, &GitHubClient::notificationsReceived, this, &MainWindow::updateNotifications);
     connect(client, &GitHubClient::errorOccurred, this, &MainWindow::showError);
@@ -104,22 +105,41 @@ void MainWindow::setClient(GitHubClient* c) {
 
     connect(client, &GitHubClient::detailsError, notificationListWidget,
             [this](const QUuid& reqId, const QString& id, const QString& err) {
+                if (reqId.isNull()) return;
+                const bool detailsMatch = m_detailRequests.value(id) == reqId;
+                const bool imageMatch = m_imageRequests.value(id) == reqId;
+                if (!detailsMatch && !imageMatch) return;
+                if (detailsMatch) m_detailRequests.remove(id);
+                if (imageMatch) m_imageRequests.remove(id);
                 this->notificationListWidget->updateError(id, err);
             });
-    connect(
-        client, &GitHubClient::detailsReceived, notificationListWidget,
-        [this](const QUuid& reqId, const QString& id, const QString& author, const QString& avatar,
-               const QString& htmlUrl) { this->notificationListWidget->updateDetails(id, author, avatar, htmlUrl); });
+    connect(client, &GitHubClient::detailsReceived, notificationListWidget,
+            [this](const QUuid& reqId, const QString& id, const QString& author, const QString& avatar,
+                   const QString& htmlUrl) {
+                if (reqId.isNull() || m_detailRequests.value(id) != reqId) return;
+                m_detailRequests.remove(id);
+                this->notificationListWidget->updateDetails(id, author, avatar, htmlUrl);
+            });
     connect(client, &GitHubClient::imageReceived, notificationListWidget,
             [this](const QUuid& reqId, const QString& id, const QPixmap& img) {
+                if (reqId.isNull() || m_imageRequests.value(id) != reqId) return;
+                m_imageRequests.remove(id);
                 this->notificationListWidget->updateImage(id, img);
             });
 
     // Wire up ListWidget requests
     connect(notificationListWidget, &NotificationListWidget::requestDetails, this,
-            [this](const QString& url, const QString& id) { this->client->fetchNotificationDetails(url, id); });
+            [this](const QString& url, const QString& id) {
+                const QUuid requestId = QUuid::createUuid();
+                m_detailRequests.insert(id, requestId);
+                client->fetchNotificationDetails(url, id, requestId);
+            });
     connect(notificationListWidget, &NotificationListWidget::requestImage, this,
-            [this](const QString& url, const QString& id) { this->client->fetchImage(url, id); });
+            [this](const QString& url, const QString& id) {
+                const QUuid requestId = QUuid::createUuid();
+                m_imageRequests.insert(id, requestId);
+                client->fetchImage(url, id, requestId);
+            });
     connect(notificationListWidget, &NotificationListWidget::markAsRead, this,
             [this](const QString& id) { this->client->markAsRead(id); });
     connect(notificationListWidget, &NotificationListWidget::requestDebugApi, this,
@@ -127,10 +147,10 @@ void MainWindow::setClient(GitHubClient* c) {
     connect(notificationListWidget, &NotificationListWidget::markAsDone, this,
             [this](const QString& id) { this->client->markAsDone(id); });
     connect(notificationListWidget, &NotificationListWidget::loadMoreRequested, this,
-            [this]() { this->client->loadMore(); });
+            [this]() { this->client->loadMore(m_currentRefreshId); });
 
     if (refreshTimer) {
-        connect(refreshTimer, &QTimer::timeout, this, [this]() { this->m_currentRefreshId = QUuid::createUuid(); this->client->checkNotifications(this->m_currentRefreshId); });
+        connect(refreshTimer, &QTimer::timeout, this, [this]() { startNotificationRefresh(); });
         int interval = SettingsDialog::getInterval();
         refreshTimer->setInterval(calculateSafeInterval(interval));
         refreshTimer->start();
@@ -138,7 +158,7 @@ void MainWindow::setClient(GitHubClient* c) {
 
     if (!m_loadedToken.isEmpty()) {
         client->setToken(m_loadedToken);
-        this->m_currentRefreshId = QUuid::createUuid(); client->checkNotifications(this->m_currentRefreshId);
+        startNotificationRefresh();
     }
 }
 
@@ -166,8 +186,8 @@ void MainWindow::showDesktopFileWarning(const QString& desktopFileName, const QS
 
 void MainWindow::updateNotifications(const QUuid& reqId, const QList<Notification>& notifications, bool append,
                                      bool hasMore) {
-    if (reqId != m_currentRefreshId) return;
-    if (!hasMore) m_currentRefreshId = QUuid(); // clear current if done
+    if (reqId.isNull() || reqId != m_currentRefreshId || !m_notificationLoading) return;
+    m_notificationLoading = false;
     m_lastCheckTime = QDateTime::currentDateTime();
     pendingAuthError = false;
     lastError.clear();
@@ -222,8 +242,9 @@ void MainWindow::onListStatusMessage(const QString& message) {
 }
 
 void MainWindow::showError(const QUuid& reqId, const QString& error) {
-    if (reqId != m_currentRefreshId) return;
-    m_currentRefreshId = QUuid();
+    if (reqId.isNull() || reqId != m_currentRefreshId || !m_notificationLoading) return;
+    m_notificationLoading = false;
+    if (notificationListWidget) notificationListWidget->resetLoadMoreState();
     if (error == lastError) return;
     lastError = error;
 
@@ -257,8 +278,8 @@ void MainWindow::showError(const QUuid& reqId, const QString& error) {
 }
 
 void MainWindow::onAuthError(const QUuid& reqId, const QString& message) {
-    if (reqId != m_currentRefreshId) return;
-    m_currentRefreshId = QUuid();
+    if (reqId.isNull() || reqId != m_currentRefreshId || !m_notificationLoading) return;
+    m_notificationLoading = false;
     pendingAuthError = true;
 
     errorLabel->setText(tr("Authentication Error: %1\n\nPlease update your token in Settings.").arg(message));
@@ -317,7 +338,7 @@ void MainWindow::showSettings() {
         int interval = SettingsDialog::getInterval();
         if (client) {
             client->setToken(newToken);
-            this->m_currentRefreshId = QUuid::createUuid(); client->checkNotifications(this->m_currentRefreshId);
+            startNotificationRefresh();
         }
         if (refreshTimer) {
             refreshTimer->setInterval(calculateSafeInterval(interval));
@@ -328,7 +349,8 @@ void MainWindow::showSettings() {
 }
 
 void MainWindow::onLoadingStarted(const QUuid& reqId) {
-    m_currentRefreshId = reqId;
+    if (reqId.isNull() || reqId != m_currentRefreshId) return;
+    m_notificationLoading = true;
     if (!notificationListWidget) return;
 
     if (statusLabel) {
@@ -364,7 +386,7 @@ void MainWindow::onTokenLoaded() {
         stackWidget->setCurrentWidget(notificationListWidget);
         if (client) {
             client->setToken(m_loadedToken);
-            this->m_currentRefreshId = QUuid::createUuid(); client->checkNotifications(this->m_currentRefreshId);
+            startNotificationRefresh();
         }
     }
 }
@@ -372,7 +394,7 @@ void MainWindow::onTokenLoaded() {
 void MainWindow::onRefreshClicked() {
     if (!client) return;
 
-    this->m_currentRefreshId = QUuid::createUuid(); client->checkNotifications(this->m_currentRefreshId);
+    startNotificationRefresh();
 
     if (refreshTimer) {
         refreshTimer->start();
@@ -1225,4 +1247,12 @@ void MainWindow::showNewIssueDialog() {
     NewIssueDialog* dialog = new NewIssueDialog(client, this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();
+}
+
+void MainWindow::startNotificationRefresh() {
+    if (!client) return;
+    m_currentRefreshId = QUuid::createUuid();
+    m_detailRequests.clear();
+    m_imageRequests.clear();
+    client->checkNotifications(m_currentRefreshId);
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -146,8 +146,10 @@ void MainWindow::setClient(GitHubClient* c) {
             [this](const QString& url) { showDebugWindow(url); });
     connect(notificationListWidget, &NotificationListWidget::markAsDone, this,
             [this](const QString& id) { this->client->markAsDone(id); });
-    connect(notificationListWidget, &NotificationListWidget::loadMoreRequested, this,
-            [this]() { this->client->loadMore(m_currentRefreshId); });
+    connect(notificationListWidget, &NotificationListWidget::loadMoreRequested, this, [this]() {
+        if (m_notificationLoading) return;
+        client->loadMore(m_currentRefreshId);
+    });
 
     if (refreshTimer) {
         connect(refreshTimer, &QTimer::timeout, this, [this]() { startNotificationRefresh(); });
@@ -196,7 +198,7 @@ void MainWindow::updateNotifications(const QUuid& reqId, const QList<Notificatio
 
     updateSelectionComboBox();
 
-    if (statusLabel) {
+    if (statusLabel && !m_notificationLoading) {
         statusLabel->setText(tr("Updated"));
     }
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -102,22 +102,21 @@ void MainWindow::setClient(GitHubClient* c) {
 
     notificationListWidget->setClient(client);
 
-    connect(client, &GitHubClient::detailsError, notificationListWidget, &NotificationListWidget::updateError);
-    connect(client, &GitHubClient::detailsReceived, notificationListWidget, &NotificationListWidget::updateDetails);
-    connect(client, &GitHubClient::imageReceived, notificationListWidget, &NotificationListWidget::updateImage);
+    connect(client, &GitHubClient::detailsError, notificationListWidget, [this](const QUuid& reqId, const QString& id, const QString& err) { this->notificationListWidget->updateError(id, err); });
+    connect(client, &GitHubClient::detailsReceived, notificationListWidget, [this](const QUuid& reqId, const QString& id, const QString& author, const QString& avatar, const QString& htmlUrl) { this->notificationListWidget->updateDetails(id, author, avatar, htmlUrl); });
+    connect(client, &GitHubClient::imageReceived, notificationListWidget, [this](const QUuid& reqId, const QString& id, const QPixmap& img) { this->notificationListWidget->updateImage(id, img); });
 
     // Wire up ListWidget requests
-    connect(notificationListWidget, &NotificationListWidget::requestDetails, client,
-            &GitHubClient::fetchNotificationDetails);
-    connect(notificationListWidget, &NotificationListWidget::requestImage, client, &GitHubClient::fetchImage);
-    connect(notificationListWidget, &NotificationListWidget::markAsRead, client, &GitHubClient::markAsRead);
+    connect(notificationListWidget, &NotificationListWidget::requestDetails, this, [this](const QString& url, const QString& id) { this->client->fetchNotificationDetails(url, id); });
+    connect(notificationListWidget, &NotificationListWidget::requestImage, this, [this](const QString& url, const QString& id) { this->client->fetchImage(url, id); });
+    connect(notificationListWidget, &NotificationListWidget::markAsRead, this, [this](const QString& id) { this->client->markAsRead(id); });
     connect(notificationListWidget, &NotificationListWidget::requestDebugApi, this,
             [this](const QString& url) { showDebugWindow(url); });
-    connect(notificationListWidget, &NotificationListWidget::markAsDone, client, &GitHubClient::markAsDone);
-    connect(notificationListWidget, &NotificationListWidget::loadMoreRequested, client, &GitHubClient::loadMore);
+    connect(notificationListWidget, &NotificationListWidget::markAsDone, this, [this](const QString& id) { this->client->markAsDone(id); });
+    connect(notificationListWidget, &NotificationListWidget::loadMoreRequested, this, [this]() { this->client->loadMore(); });
 
     if (refreshTimer) {
-        connect(refreshTimer, &QTimer::timeout, client, &GitHubClient::checkNotifications);
+        connect(refreshTimer, &QTimer::timeout, this, [this]() { this->client->checkNotifications(); });
         int interval = SettingsDialog::getInterval();
         refreshTimer->setInterval(calculateSafeInterval(interval));
         refreshTimer->start();
@@ -151,7 +150,9 @@ void MainWindow::showDesktopFileWarning(const QString& desktopFileName, const QS
 // Slots
 // -----------------------------------------------------------------------------
 
-void MainWindow::updateNotifications(const QList<Notification>& notifications, bool append, bool hasMore) {
+void MainWindow::updateNotifications(const QUuid& reqId, const QList<Notification>& notifications, bool append, bool hasMore) {
+    if (!m_notificationRequests.contains(reqId)) return;
+    if (!hasMore) m_notificationRequests.remove(reqId);
     m_lastCheckTime = QDateTime::currentDateTime();
     pendingAuthError = false;
     lastError.clear();
@@ -205,7 +206,9 @@ void MainWindow::onListStatusMessage(const QString& message) {
     }
 }
 
-void MainWindow::showError(const QString& error) {
+void MainWindow::showError(const QUuid& reqId, const QString& error) {
+    if (!m_notificationRequests.contains(reqId)) return;
+    m_notificationRequests.remove(reqId);
     if (error == lastError) return;
     lastError = error;
 
@@ -238,7 +241,9 @@ void MainWindow::showError(const QString& error) {
     updateTrayToolTip();
 }
 
-void MainWindow::onAuthError(const QString& message) {
+void MainWindow::onAuthError(const QUuid& reqId, const QString& message) {
+    if (!m_notificationRequests.contains(reqId)) return;
+    m_notificationRequests.remove(reqId);
     pendingAuthError = true;
 
     errorLabel->setText(tr("Authentication Error: %1\n\nPlease update your token in Settings.").arg(message));
@@ -307,7 +312,8 @@ void MainWindow::showSettings() {
     }
 }
 
-void MainWindow::onLoadingStarted() {
+void MainWindow::onLoadingStarted(const QUuid& reqId) {
+    m_notificationRequests.insert(reqId);
     if (!notificationListWidget) return;
 
     if (statusLabel) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -130,7 +130,7 @@ void MainWindow::setClient(GitHubClient* c) {
             [this]() { this->client->loadMore(); });
 
     if (refreshTimer) {
-        connect(refreshTimer, &QTimer::timeout, this, [this]() { this->client->checkNotifications(); });
+        connect(refreshTimer, &QTimer::timeout, this, [this]() { this->m_currentRefreshId = QUuid::createUuid(); this->client->checkNotifications(this->m_currentRefreshId); });
         int interval = SettingsDialog::getInterval();
         refreshTimer->setInterval(calculateSafeInterval(interval));
         refreshTimer->start();
@@ -138,7 +138,7 @@ void MainWindow::setClient(GitHubClient* c) {
 
     if (!m_loadedToken.isEmpty()) {
         client->setToken(m_loadedToken);
-        client->checkNotifications();
+        this->m_currentRefreshId = QUuid::createUuid(); client->checkNotifications(this->m_currentRefreshId);
     }
 }
 
@@ -166,8 +166,8 @@ void MainWindow::showDesktopFileWarning(const QString& desktopFileName, const QS
 
 void MainWindow::updateNotifications(const QUuid& reqId, const QList<Notification>& notifications, bool append,
                                      bool hasMore) {
-    if (!m_notificationRequests.contains(reqId)) return;
-    if (!hasMore) m_notificationRequests.remove(reqId);
+    if (reqId != m_currentRefreshId) return;
+    if (!hasMore) m_currentRefreshId = QUuid(); // clear current if done
     m_lastCheckTime = QDateTime::currentDateTime();
     pendingAuthError = false;
     lastError.clear();
@@ -222,8 +222,8 @@ void MainWindow::onListStatusMessage(const QString& message) {
 }
 
 void MainWindow::showError(const QUuid& reqId, const QString& error) {
-    if (!m_notificationRequests.contains(reqId)) return;
-    m_notificationRequests.remove(reqId);
+    if (reqId != m_currentRefreshId) return;
+    m_currentRefreshId = QUuid();
     if (error == lastError) return;
     lastError = error;
 
@@ -257,8 +257,8 @@ void MainWindow::showError(const QUuid& reqId, const QString& error) {
 }
 
 void MainWindow::onAuthError(const QUuid& reqId, const QString& message) {
-    if (!m_notificationRequests.contains(reqId)) return;
-    m_notificationRequests.remove(reqId);
+    if (reqId != m_currentRefreshId) return;
+    m_currentRefreshId = QUuid();
     pendingAuthError = true;
 
     errorLabel->setText(tr("Authentication Error: %1\n\nPlease update your token in Settings.").arg(message));
@@ -317,7 +317,7 @@ void MainWindow::showSettings() {
         int interval = SettingsDialog::getInterval();
         if (client) {
             client->setToken(newToken);
-            client->checkNotifications();
+            this->m_currentRefreshId = QUuid::createUuid(); client->checkNotifications(this->m_currentRefreshId);
         }
         if (refreshTimer) {
             refreshTimer->setInterval(calculateSafeInterval(interval));
@@ -328,7 +328,7 @@ void MainWindow::showSettings() {
 }
 
 void MainWindow::onLoadingStarted(const QUuid& reqId) {
-    m_notificationRequests.insert(reqId);
+    m_currentRefreshId = reqId;
     if (!notificationListWidget) return;
 
     if (statusLabel) {
@@ -364,7 +364,7 @@ void MainWindow::onTokenLoaded() {
         stackWidget->setCurrentWidget(notificationListWidget);
         if (client) {
             client->setToken(m_loadedToken);
-            client->checkNotifications();
+            this->m_currentRefreshId = QUuid::createUuid(); client->checkNotifications(this->m_currentRefreshId);
         }
     }
 }
@@ -372,7 +372,7 @@ void MainWindow::onTokenLoaded() {
 void MainWindow::onRefreshClicked() {
     if (!client) return;
 
-    client->checkNotifications();
+    this->m_currentRefreshId = QUuid::createUuid(); client->checkNotifications(this->m_currentRefreshId);
 
     if (refreshTimer) {
         refreshTimer->start();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -102,18 +102,32 @@ void MainWindow::setClient(GitHubClient* c) {
 
     notificationListWidget->setClient(client);
 
-    connect(client, &GitHubClient::detailsError, notificationListWidget, [this](const QUuid& reqId, const QString& id, const QString& err) { this->notificationListWidget->updateError(id, err); });
-    connect(client, &GitHubClient::detailsReceived, notificationListWidget, [this](const QUuid& reqId, const QString& id, const QString& author, const QString& avatar, const QString& htmlUrl) { this->notificationListWidget->updateDetails(id, author, avatar, htmlUrl); });
-    connect(client, &GitHubClient::imageReceived, notificationListWidget, [this](const QUuid& reqId, const QString& id, const QPixmap& img) { this->notificationListWidget->updateImage(id, img); });
+    connect(client, &GitHubClient::detailsError, notificationListWidget,
+            [this](const QUuid& reqId, const QString& id, const QString& err) {
+                this->notificationListWidget->updateError(id, err);
+            });
+    connect(
+        client, &GitHubClient::detailsReceived, notificationListWidget,
+        [this](const QUuid& reqId, const QString& id, const QString& author, const QString& avatar,
+               const QString& htmlUrl) { this->notificationListWidget->updateDetails(id, author, avatar, htmlUrl); });
+    connect(client, &GitHubClient::imageReceived, notificationListWidget,
+            [this](const QUuid& reqId, const QString& id, const QPixmap& img) {
+                this->notificationListWidget->updateImage(id, img);
+            });
 
     // Wire up ListWidget requests
-    connect(notificationListWidget, &NotificationListWidget::requestDetails, this, [this](const QString& url, const QString& id) { this->client->fetchNotificationDetails(url, id); });
-    connect(notificationListWidget, &NotificationListWidget::requestImage, this, [this](const QString& url, const QString& id) { this->client->fetchImage(url, id); });
-    connect(notificationListWidget, &NotificationListWidget::markAsRead, this, [this](const QString& id) { this->client->markAsRead(id); });
+    connect(notificationListWidget, &NotificationListWidget::requestDetails, this,
+            [this](const QString& url, const QString& id) { this->client->fetchNotificationDetails(url, id); });
+    connect(notificationListWidget, &NotificationListWidget::requestImage, this,
+            [this](const QString& url, const QString& id) { this->client->fetchImage(url, id); });
+    connect(notificationListWidget, &NotificationListWidget::markAsRead, this,
+            [this](const QString& id) { this->client->markAsRead(id); });
     connect(notificationListWidget, &NotificationListWidget::requestDebugApi, this,
             [this](const QString& url) { showDebugWindow(url); });
-    connect(notificationListWidget, &NotificationListWidget::markAsDone, this, [this](const QString& id) { this->client->markAsDone(id); });
-    connect(notificationListWidget, &NotificationListWidget::loadMoreRequested, this, [this]() { this->client->loadMore(); });
+    connect(notificationListWidget, &NotificationListWidget::markAsDone, this,
+            [this](const QString& id) { this->client->markAsDone(id); });
+    connect(notificationListWidget, &NotificationListWidget::loadMoreRequested, this,
+            [this]() { this->client->loadMore(); });
 
     if (refreshTimer) {
         connect(refreshTimer, &QTimer::timeout, this, [this]() { this->client->checkNotifications(); });
@@ -150,7 +164,8 @@ void MainWindow::showDesktopFileWarning(const QString& desktopFileName, const QS
 // Slots
 // -----------------------------------------------------------------------------
 
-void MainWindow::updateNotifications(const QUuid& reqId, const QList<Notification>& notifications, bool append, bool hasMore) {
+void MainWindow::updateNotifications(const QUuid& reqId, const QList<Notification>& notifications, bool append,
+                                     bool hasMore) {
     if (!m_notificationRequests.contains(reqId)) return;
     if (!hasMore) m_notificationRequests.remove(reqId);
     m_lastCheckTime = QDateTime::currentDateTime();

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -43,15 +43,15 @@ class MainWindow : public KXmlGuiWindow {
     void showDesktopFileWarning(const QString& desktopFileName, const QStringList& appPaths);
 
    public slots:
-    void updateNotifications(const QList<Notification>& notifications, bool append, bool hasMore);
-    void showError(const QString& error);
-    void onAuthError(const QString& message);
+    void updateNotifications(const QUuid& reqId, const QList<Notification>& notifications, bool append, bool hasMore);
+    void showError(const QUuid& reqId, const QString& error);
+    void onAuthError(const QUuid& reqId, const QString& message);
 
    private slots:
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
     void onTrayMessageClicked();
     void showSettings();
-    void onLoadingStarted();
+    void onLoadingStarted(const QUuid& reqId);
     void onAuthNotificationSettingsClicked();
     void dismissAllNotifications();
     void onTokenLoaded();
@@ -109,6 +109,7 @@ class MainWindow : public KXmlGuiWindow {
     QPointer<DebugWindow> debugWindow;
     QPointer<RepoListWindow> repoListWindow;
     QPointer<TrendingWindow> trendingWindow;
+    QSet<QUuid> m_notificationRequests;
     QSystemTrayIcon* trayIcon;
     QMenu* trayIconMenu;
     NotificationListWidget* notificationListWidget;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -109,7 +109,7 @@ class MainWindow : public KXmlGuiWindow {
     QPointer<DebugWindow> debugWindow;
     QPointer<RepoListWindow> repoListWindow;
     QPointer<TrendingWindow> trendingWindow;
-    QSet<QUuid> m_notificationRequests;
+    QUuid m_currentRefreshId;
     QSystemTrayIcon* trayIcon;
     QMenu* trayIconMenu;
     NotificationListWidget* notificationListWidget;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -35,6 +35,8 @@ class NewIssueDialog;
 
 class MainWindow : public KXmlGuiWindow {
     Q_OBJECT
+    friend class TestRequestConsumers;
+
    public:
     explicit MainWindow(QWidget* parent = nullptr);
     ~MainWindow();
@@ -81,6 +83,7 @@ class MainWindow : public KXmlGuiWindow {
     void closeEvent(QCloseEvent* event) override;
 
    private:
+    void startNotificationRefresh();
     // Helpers
     void createTrayIcon();
     void updateTrayMenu();
@@ -110,6 +113,9 @@ class MainWindow : public KXmlGuiWindow {
     QPointer<RepoListWindow> repoListWindow;
     QPointer<TrendingWindow> trendingWindow;
     QUuid m_currentRefreshId;
+    bool m_notificationLoading = false;
+    QHash<QString, QUuid> m_detailRequests;
+    QHash<QString, QUuid> m_imageRequests;
     QSystemTrayIcon* trayIcon;
     QMenu* trayIconMenu;
     NotificationListWidget* notificationListWidget;

--- a/src/NewIssueDialog.cpp
+++ b/src/NewIssueDialog.cpp
@@ -288,7 +288,7 @@ void NewIssueDialog::onErrorOccurred(const QUuid& reqId, const QString& error) {
     } else if (reqId == m_verifyRequestId || reqId == m_createIssueRequestId) {
         m_createButton->setEnabled(true);
     } else {
-        return; // ignore unknown
+        return;  // ignore unknown
     }
 
     QString errMsg = tr("Error: %1").arg(error);

--- a/src/NewIssueDialog.cpp
+++ b/src/NewIssueDialog.cpp
@@ -184,10 +184,11 @@ void NewIssueDialog::verifyRepo() {
     }
 
     // Not in cache, verify via API
-    m_client->verifyRepo(m_currentVerifyRepo);
+    m_verifyRequestId = m_client->verifyRepo(m_currentVerifyRepo);
 }
 
-void NewIssueDialog::onRepoVerified(const QString& repoFullName, bool exists) {
+void NewIssueDialog::onRepoVerified(const QUuid& reqId, const QString& repoFullName, bool exists) {
+    if (reqId != m_verifyRequestId) return;
     if (repoFullName.compare(m_currentVerifyRepo, Qt::CaseInsensitive) != 0) return;
 
     if (exists) {
@@ -217,10 +218,11 @@ void NewIssueDialog::onCreateClicked() {
     m_statusLabel->setText(tr("Creating issue..."));
     m_statusLabel->setStyleSheet("color: gray;");
 
-    m_client->createIssue(repoName, title, body, assignee);
+    m_createIssueRequestId = m_client->createIssue(repoName, title, body, assignee);
 }
 
-void NewIssueDialog::onIssueCreated(const QByteArray& data) {
+void NewIssueDialog::onIssueCreated(const QUuid& reqId, const QByteArray& data) {
+    if (reqId != m_createIssueRequestId) return;
     QJsonDocument doc = QJsonDocument::fromJson(data);
     if (doc.isObject() && doc.object().contains("html_url")) {
         QString url = doc.object()["html_url"].toString();
@@ -251,17 +253,18 @@ void NewIssueDialog::onRefreshClicked() {
     m_statusLabel->setText(tr("Refreshing cache..."));
     m_statusLabel->setStyleSheet("color: gray;");
     m_allRepos = QJsonArray();
-    m_client->fetchUserRepos();
+    m_repoLoadRequestId = m_client->fetchUserRepos();
 }
 
-void NewIssueDialog::onReposReceived(const QJsonArray& repos, const QString& nextPageUrl) {
+void NewIssueDialog::onReposReceived(const QUuid& reqId, const QJsonArray& repos, const QString& nextPageUrl) {
+    if (reqId != m_repoLoadRequestId) return;
     if (!m_isFetchingRepos) return;
     for (int i = 0; i < repos.size(); ++i) {
         m_allRepos.append(repos[i]);
     }
 
     if (!nextPageUrl.isEmpty()) {
-        m_client->fetchUserRepos(nextPageUrl);
+        m_client->fetchUserRepos(nextPageUrl, reqId);
     } else {
         saveCache();
         loadCache();
@@ -278,9 +281,16 @@ void NewIssueDialog::onReposReceived(const QJsonArray& repos, const QString& nex
     }
 }
 
-void NewIssueDialog::onErrorOccurred(const QString& error) {
-    m_refreshButton->setEnabled(true);
-    m_createButton->setEnabled(true);
+void NewIssueDialog::onErrorOccurred(const QUuid& reqId, const QString& error) {
+    if (reqId == m_repoLoadRequestId) {
+        m_refreshButton->setEnabled(true);
+        m_isFetchingRepos = false;
+    } else if (reqId == m_verifyRequestId || reqId == m_createIssueRequestId) {
+        m_createButton->setEnabled(true);
+    } else {
+        return; // ignore unknown
+    }
+
     QString errMsg = tr("Error: %1").arg(error);
     if (error.contains("404") || error.contains("Not Found")) {
         errMsg +=

--- a/src/NewIssueDialog.cpp
+++ b/src/NewIssueDialog.cpp
@@ -21,6 +21,7 @@ NewIssueDialog::NewIssueDialog(GitHubClient* client, QWidget* parent)
     connect(m_client, &GitHubClient::repoVerified, this, &NewIssueDialog::onRepoVerified);
     connect(m_client, &GitHubClient::userReposReceived, this, &NewIssueDialog::onReposReceived);
     connect(m_client, &GitHubClient::errorOccurred, this, &NewIssueDialog::onErrorOccurred);
+    connect(m_client, &GitHubClient::authError, this, &NewIssueDialog::onErrorOccurred);
     connect(m_client, &GitHubClient::issueCreated, this, &NewIssueDialog::onIssueCreated);
 
     loadCache();
@@ -153,6 +154,10 @@ void NewIssueDialog::saveCache() {
 }
 
 void NewIssueDialog::onRepoTextChanged(const QString& text) {
+    m_verifyTimer->stop();
+    m_verifyRequestId = QUuid();
+    m_currentVerifyRepo.clear();
+    m_repositoryVerified = false;
     m_createButton->setEnabled(false);
 
     // Basic format check
@@ -178,23 +183,27 @@ void NewIssueDialog::verifyRepo() {
         if (fullName.compare(m_currentVerifyRepo, Qt::CaseInsensitive) == 0) {
             m_statusLabel->setText(tr("Repository found in cache."));
             m_statusLabel->setStyleSheet("color: green;");
-            m_createButton->setEnabled(true);
+            m_repositoryVerified = true;
+            m_createButton->setEnabled(m_createIssueRequestId.isNull());
             return;
         }
     }
 
     // Not in cache, verify via API
-    m_verifyRequestId = m_client->verifyRepo(m_currentVerifyRepo);
+    m_verifyRequestId = QUuid::createUuid();
+    m_client->verifyRepo(m_currentVerifyRepo, m_verifyRequestId);
 }
 
 void NewIssueDialog::onRepoVerified(const QUuid& reqId, const QString& repoFullName, bool exists) {
-    if (reqId != m_verifyRequestId) return;
+    if (reqId.isNull() || reqId != m_verifyRequestId) return;
+    m_verifyRequestId = QUuid();
     if (repoFullName.compare(m_currentVerifyRepo, Qt::CaseInsensitive) != 0) return;
 
+    m_repositoryVerified = exists;
     if (exists) {
         m_statusLabel->setText(tr("Repository verified successfully."));
         m_statusLabel->setStyleSheet("color: green;");
-        m_createButton->setEnabled(true);
+        m_createButton->setEnabled(m_createIssueRequestId.isNull());
     } else {
         m_statusLabel->setText(tr("Repository not found or not accessible."));
         m_statusLabel->setStyleSheet("color: red;");
@@ -218,11 +227,14 @@ void NewIssueDialog::onCreateClicked() {
     m_statusLabel->setText(tr("Creating issue..."));
     m_statusLabel->setStyleSheet("color: gray;");
 
-    m_createIssueRequestId = m_client->createIssue(repoName, title, body, assignee);
+    m_createIssueRequestId = QUuid::createUuid();
+    m_client->createIssue(repoName, title, body, assignee, m_createIssueRequestId);
 }
 
 void NewIssueDialog::onIssueCreated(const QUuid& reqId, const QByteArray& data) {
-    if (reqId != m_createIssueRequestId) return;
+    if (reqId.isNull() || reqId != m_createIssueRequestId) return;
+    m_createIssueRequestId = QUuid();
+    m_createButton->setEnabled(m_repositoryVerified);
     QJsonDocument doc = QJsonDocument::fromJson(data);
     if (doc.isObject() && doc.object().contains("html_url")) {
         QString url = doc.object()["html_url"].toString();
@@ -243,7 +255,7 @@ void NewIssueDialog::onIssueCreated(const QUuid& reqId, const QByteArray& data) 
         }
         m_statusLabel->setText(errMsg);
         m_statusLabel->setStyleSheet("color: red;");
-        m_createButton->setEnabled(true);
+        m_createButton->setEnabled(m_repositoryVerified);
     }
 }
 
@@ -253,7 +265,8 @@ void NewIssueDialog::onRefreshClicked() {
     m_statusLabel->setText(tr("Refreshing cache..."));
     m_statusLabel->setStyleSheet("color: gray;");
     m_allRepos = QJsonArray();
-    m_repoLoadRequestId = m_client->fetchUserRepos();
+    m_repoLoadRequestId = QUuid::createUuid();
+    m_client->fetchUserRepos(QString(), m_repoLoadRequestId);
 }
 
 void NewIssueDialog::onReposReceived(const QUuid& reqId, const QJsonArray& repos, const QString& nextPageUrl) {
@@ -266,6 +279,7 @@ void NewIssueDialog::onReposReceived(const QUuid& reqId, const QJsonArray& repos
     if (!nextPageUrl.isEmpty()) {
         m_client->fetchUserRepos(nextPageUrl, reqId);
     } else {
+        m_repoLoadRequestId = QUuid();
         saveCache();
         loadCache();
 
@@ -282,11 +296,17 @@ void NewIssueDialog::onReposReceived(const QUuid& reqId, const QJsonArray& repos
 }
 
 void NewIssueDialog::onErrorOccurred(const QUuid& reqId, const QString& error) {
+    if (reqId.isNull()) return;
     if (reqId == m_repoLoadRequestId) {
+        m_repoLoadRequestId = QUuid();
         m_refreshButton->setEnabled(true);
         m_isFetchingRepos = false;
-    } else if (reqId == m_verifyRequestId || reqId == m_createIssueRequestId) {
-        m_createButton->setEnabled(true);
+    } else if (reqId == m_verifyRequestId) {
+        m_verifyRequestId = QUuid();
+        m_createButton->setEnabled(false);
+    } else if (reqId == m_createIssueRequestId) {
+        m_createIssueRequestId = QUuid();
+        m_createButton->setEnabled(m_repositoryVerified);
     } else {
         return;  // ignore unknown
     }

--- a/src/NewIssueDialog.h
+++ b/src/NewIssueDialog.h
@@ -22,12 +22,12 @@ class NewIssueDialog : public QDialog {
    private slots:
     void onRepoTextChanged(const QString& text);
     void verifyRepo();
-    void onRepoVerified(const QString& repoFullName, bool exists);
+    void onRepoVerified(const QUuid& reqId, const QString& repoFullName, bool exists);
     void onCreateClicked();
     void onRefreshClicked();
-    void onReposReceived(const QJsonArray& repos, const QString& nextPageUrl);
-    void onIssueCreated(const QByteArray& data);
-    void onErrorOccurred(const QString& error);
+    void onReposReceived(const QUuid& reqId, const QJsonArray& repos, const QString& nextPageUrl);
+    void onIssueCreated(const QUuid& reqId, const QByteArray& data);
+    void onErrorOccurred(const QUuid& reqId, const QString& error);
 
    private:
     void setupUI();
@@ -35,6 +35,9 @@ class NewIssueDialog : public QDialog {
     void saveCache();
 
     GitHubClient* m_client;
+    QUuid m_repoLoadRequestId;
+    QUuid m_verifyRequestId;
+    QUuid m_createIssueRequestId;
     QComboBox* m_repoComboBox;
     QLineEdit* m_titleEdit;
     QTextEdit* m_bodyEdit;

--- a/src/NewIssueDialog.h
+++ b/src/NewIssueDialog.h
@@ -14,6 +14,7 @@
 
 class NewIssueDialog : public QDialog {
     Q_OBJECT
+    friend class TestRequestConsumers;
 
    public:
     explicit NewIssueDialog(GitHubClient* client, QWidget* parent = nullptr);
@@ -38,6 +39,7 @@ class NewIssueDialog : public QDialog {
     QUuid m_repoLoadRequestId;
     QUuid m_verifyRequestId;
     QUuid m_createIssueRequestId;
+    bool m_repositoryVerified = false;
     QComboBox* m_repoComboBox;
     QLineEdit* m_titleEdit;
     QTextEdit* m_bodyEdit;

--- a/src/NotificationListWidget.cpp
+++ b/src/NotificationListWidget.cpp
@@ -1,5 +1,4 @@
 #include "NotificationListWidget.h"
-#include <QPointer>
 
 #include <QApplication>
 #include <QClipboard>
@@ -11,6 +10,7 @@
 #include <QJsonDocument>
 #include <QListWidgetItem>
 #include <QMessageBox>
+#include <QPointer>
 #include <QPushButton>
 #include <QResizeEvent>
 #include <QScrollBar>

--- a/src/NotificationListWidget.cpp
+++ b/src/NotificationListWidget.cpp
@@ -1,4 +1,5 @@
 #include "NotificationListWidget.h"
+#include <QPointer>
 
 #include <QApplication>
 #include <QClipboard>

--- a/src/NotificationListWidget.h
+++ b/src/NotificationListWidget.h
@@ -18,6 +18,8 @@ class NotificationItemWidget;
 
 class NotificationListWidget : public QWidget {
     Q_OBJECT
+    friend class TestRequestConsumers;
+
    public:
     explicit NotificationListWidget(QWidget* parent = nullptr);
 

--- a/src/PullRequestWindow.cpp
+++ b/src/PullRequestWindow.cpp
@@ -11,6 +11,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMessageBox>
+#include <QStatusBar>
 #include <QTextEdit>
 #include <QUrl>
 
@@ -94,16 +95,23 @@ CommentWidget::CommentWidget(const QString& author, const QString& body, const Q
 
 #include "PullRequestWindow.moc"
 
-PullRequestWindow::PullRequestWindow(const Notification& n, GitHubClient* client, QWidget* parent)
+PullRequestWindow::PullRequestWindow(const Notification& n, GitHubClient* client, QWidget* parent,
+                                     QNetworkAccessManager* networkManager)
     : KXmlGuiWindow(parent, Qt::Window),
       m_notification(n),
       m_client(client),
-      m_manager(new QNetworkAccessManager(this)) {
+      m_manager(networkManager ? networkManager : new QNetworkAccessManager(this)) {
     setWindowTitle(tr("Pull Request - %1").arg(n.title));
     resize(800, 600);
 
     setupUi();
 
+    m_requestStatus = new QLabel(this);
+    m_requestStatus->setTextFormat(Qt::PlainText);
+    statusBar()->addWidget(m_requestStatus, 1);
+    m_retryButton = new QPushButton(tr("Retry"), this);
+    statusBar()->addPermanentWidget(m_retryButton);
+    connect(m_retryButton, &QPushButton::clicked, this, &PullRequestWindow::fetchPrDetails);
     fetchPrDetails();
 }
 
@@ -228,14 +236,24 @@ void PullRequestWindow::setupUi() {
 }
 
 void PullRequestWindow::fetchPrDetails() {
+    m_detailsGeneration = QUuid::createUuid();
+    m_requestStatus->setText(tr("Loading PR details..."));
+    m_retryButton->setEnabled(false);
     QUrl url(m_notification.url);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
     QNetworkReply* reply = m_manager->get(request);
+    reply->setProperty("generation", m_detailsGeneration);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onPrDetailsReply(reply); });
 }
 
 void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
+    if (reply->property("generation").toUuid() != m_detailsGeneration) {
+        reply->deleteLater();
+        return;
+    }
+    m_retryButton->setEnabled(true);
     if (reply->error() == QNetworkReply::NoError) {
+        m_requestStatus->setText(tr("PR details loaded."));
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
         m_rawJsonStr = QString::fromUtf8(doc.toJson(QJsonDocument::Indented));
@@ -252,6 +270,13 @@ void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
         QString issueUrl = obj["issue_url"].toString();
         m_issueCommentsUrl = issueUrl + "/comments";
         m_timelineUrl = issueUrl + "/timeline";
+
+        while (QLayoutItem* item = m_commentsContainerLayout->takeAt(0)) {
+            delete item->widget();
+            delete item;
+        }
+
+        m_commentsContainerLayout->addStretch();
 
         // Add the PR body as the first comment
         QString author = obj["user"].toObject()["login"].toString();
@@ -305,7 +330,7 @@ void PullRequestWindow::onPrDetailsReply(QNetworkReply* reply) {
         fetchCommits();
         fetchFiles();
     } else {
-        QMessageBox::warning(this, tr("Error"), tr("Failed to fetch PR details: %1").arg(reply->errorString()));
+        m_requestStatus->setText(tr("Failed to fetch PR details: %1. Retry to try again.").arg(reply->errorString()));
     }
     reply->deleteLater();
 }
@@ -315,10 +340,15 @@ void PullRequestWindow::fetchTimeline() {
     QUrl url(m_timelineUrl);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
     QNetworkReply* reply = m_manager->get(request);
+    reply->setProperty("generation", m_detailsGeneration);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onTimelineReply(reply); });
 }
 
 void PullRequestWindow::onTimelineReply(QNetworkReply* reply) {
+    if (reply->property("generation").toUuid() != m_detailsGeneration) {
+        reply->deleteLater();
+        return;
+    }
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -434,10 +464,15 @@ void PullRequestWindow::fetchReviewComments() {
     QUrl url(m_reviewCommentsUrl);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
     QNetworkReply* reply = m_manager->get(request);
+    reply->setProperty("generation", m_detailsGeneration);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onReviewCommentsReply(reply); });
 }
 
 void PullRequestWindow::onReviewCommentsReply(QNetworkReply* reply) {
+    if (reply->property("generation").toUuid() != m_detailsGeneration) {
+        reply->deleteLater();
+        return;
+    }
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -463,10 +498,15 @@ void PullRequestWindow::fetchCommits() {
     QUrl url(m_commitsUrl);
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
     QNetworkReply* reply = m_manager->get(request);
+    reply->setProperty("generation", m_detailsGeneration);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onCommitsReply(reply); });
 }
 
 void PullRequestWindow::onCommitsReply(QNetworkReply* reply) {
+    if (reply->property("generation").toUuid() != m_detailsGeneration) {
+        reply->deleteLater();
+        return;
+    }
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -495,10 +535,15 @@ void PullRequestWindow::fetchFiles() {
     QUrl url(m_notification.url + "/files");
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
     QNetworkReply* reply = m_manager->get(request);
+    reply->setProperty("generation", m_detailsGeneration);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onFilesReply(reply); });
 }
 
 void PullRequestWindow::onFilesReply(QNetworkReply* reply) {
+    if (reply->property("generation").toUuid() != m_detailsGeneration) {
+        reply->deleteLater();
+        return;
+    }
     if (reply->error() == QNetworkReply::NoError) {
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -573,7 +618,9 @@ void PullRequestWindow::onCommentButtonClicked() {
     QNetworkRequest request = m_client->createAuthenticatedRequest(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
 
+    m_commentRequestId = QUuid::createUuid();
     QNetworkReply* reply = m_manager->post(request, data);
+    reply->setProperty("reqId", m_commentRequestId);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { onPostCommentReply(reply); });
 }
 
@@ -616,6 +663,11 @@ void PullRequestWindow::onViewRawJson() {
 }
 
 void PullRequestWindow::onPostCommentReply(QNetworkReply* reply) {
+    if (reply->property("reqId").toUuid() != m_commentRequestId) {
+        reply->deleteLater();
+        return;
+    }
+    m_commentRequestId = QUuid();
     m_commentButton->setEnabled(true);
     if (reply->error() == QNetworkReply::NoError) {
         m_replyEdit->clear();

--- a/src/PullRequestWindow.h
+++ b/src/PullRequestWindow.h
@@ -20,8 +20,11 @@
 
 class PullRequestWindow : public KXmlGuiWindow {
     Q_OBJECT
+    friend class TestRequestConsumers;
+
    public:
-    explicit PullRequestWindow(const Notification& n, GitHubClient* client, QWidget* parent = nullptr);
+    explicit PullRequestWindow(const Notification& n, GitHubClient* client, QWidget* parent = nullptr,
+                               QNetworkAccessManager* networkManager = nullptr);
 
    private slots:
     void fetchPrDetails();
@@ -49,6 +52,10 @@ class PullRequestWindow : public KXmlGuiWindow {
     Notification m_notification;
     GitHubClient* m_client;
     QNetworkAccessManager* m_manager;
+    QUuid m_detailsGeneration;
+    QUuid m_commentRequestId;
+    QLabel* m_requestStatus;
+    QPushButton* m_retryButton;
 
     QTabWidget* m_tabWidget;
 

--- a/src/RepoListWindow.cpp
+++ b/src/RepoListWindow.cpp
@@ -74,6 +74,7 @@ RepoListWindow::RepoListWindow(GitHubClient* client, QWidget* parent)
 
     connect(m_client, &GitHubClient::userReposReceived, this, &RepoListWindow::onReposReceived);
     connect(m_client, &GitHubClient::errorOccurred, this, &RepoListWindow::onError);
+    connect(m_client, &GitHubClient::authError, this, &RepoListWindow::onError);
 
     m_updateTimer = new QTimer(this);
     connect(m_updateTimer, &QTimer::timeout, this, &RepoListWindow::updateTimerLabel);
@@ -167,8 +168,9 @@ void RepoListWindow::setupUI() {
 void RepoListWindow::onRefreshClicked() {
     m_allRepos = QJsonArray();  // Clear previous
     if (m_refreshAction) m_refreshAction->setEnabled(false);
-    m_refreshRequestId = m_client->fetchUserRepos();
+    m_refreshRequestId = QUuid::createUuid();
     if (m_statusBar) m_statusBar->showMessage(tr("Fetching repositories..."));
+    m_client->fetchUserRepos(QString(), m_refreshRequestId);
 }
 
 void RepoListWindow::onFilterChanged() { addReposToTable(m_allRepos); }
@@ -210,7 +212,7 @@ void RepoListWindow::onExportClicked() {
 }
 
 void RepoListWindow::onReposReceived(const QUuid& reqId, const QJsonArray& repos, const QString& nextPageUrl) {
-    if (reqId != m_refreshRequestId) return;
+    if (reqId.isNull() || reqId != m_refreshRequestId) return;
 
     for (const QJsonValue& val : repos) {
         m_allRepos.append(val);
@@ -219,6 +221,7 @@ void RepoListWindow::onReposReceived(const QUuid& reqId, const QJsonArray& repos
     if (!nextPageUrl.isEmpty()) {
         m_client->fetchUserRepos(nextPageUrl, reqId);
     } else {
+        m_refreshRequestId = QUuid();
         m_lastRefresh = QDateTime::currentDateTime();
         saveCache();
         addReposToTable(m_allRepos);
@@ -364,7 +367,8 @@ void RepoListWindow::onCustomContextMenuRequested(const QPoint& pos) {
 }
 
 void RepoListWindow::onError(const QUuid& reqId, const QString& error) {
-    if (reqId != m_refreshRequestId) return;
+    if (reqId.isNull() || reqId != m_refreshRequestId) return;
+    m_refreshRequestId = QUuid();
     if (m_refreshAction) m_refreshAction->setEnabled(true);
 
     if (m_statusBar) {

--- a/src/RepoListWindow.cpp
+++ b/src/RepoListWindow.cpp
@@ -106,7 +106,7 @@ void RepoListWindow::setupUI() {
     setCentralWidget(m_table);
 
     // Actions
-    QAction* refreshAction = KStandardAction::redisplay(this, &RepoListWindow::onRefreshClicked, actionCollection());
+    m_refreshAction = KStandardAction::redisplay(this, &RepoListWindow::onRefreshClicked, actionCollection());
 
     QAction* exportAction = new QAction(QIcon::fromTheme("document-export"), tr("Export to CSV"), this);
     connect(exportAction, &QAction::triggered, this, &RepoListWindow::onExportClicked);
@@ -151,7 +151,7 @@ void RepoListWindow::setupUI() {
     });
     connect(m_filterEdit, &QLineEdit::textChanged, this, &RepoListWindow::onFilterChanged);
 
-    m_toolbar->addAction(refreshAction);
+    m_toolbar->addAction(m_refreshAction);
     m_toolbar->addAction(exportAction);
     m_toolbar->addSeparator();
     m_toolbar->addWidget(new QLabel(tr("Filter: "), this));
@@ -166,7 +166,8 @@ void RepoListWindow::setupUI() {
 
 void RepoListWindow::onRefreshClicked() {
     m_allRepos = QJsonArray();  // Clear previous
-    m_client->fetchUserRepos();
+    if (m_refreshAction) m_refreshAction->setEnabled(false);
+    m_refreshRequestId = m_client->fetchUserRepos();
     if (m_statusBar) m_statusBar->showMessage(tr("Fetching repositories..."));
 }
 
@@ -208,19 +209,22 @@ void RepoListWindow::onExportClicked() {
     m_statusBar->showMessage(tr("Exported to %1").arg(fileName), 5000);
 }
 
-void RepoListWindow::onReposReceived(const QJsonArray& repos, const QString& nextPageUrl) {
+void RepoListWindow::onReposReceived(const QUuid& reqId, const QJsonArray& repos, const QString& nextPageUrl) {
+    if (reqId != m_refreshRequestId) return;
+
     for (const QJsonValue& val : repos) {
         m_allRepos.append(val);
     }
 
     if (!nextPageUrl.isEmpty()) {
-        m_client->fetchUserRepos(nextPageUrl);
+        m_client->fetchUserRepos(nextPageUrl, reqId);
     } else {
         m_lastRefresh = QDateTime::currentDateTime();
         saveCache();
         addReposToTable(m_allRepos);
         updateTimerLabel();
         if (m_statusBar) m_statusBar->showMessage(tr("Finished fetching repositories."), 5000);
+        if (m_refreshAction) m_refreshAction->setEnabled(true);
     }
 }
 
@@ -359,7 +363,10 @@ void RepoListWindow::onCustomContextMenuRequested(const QPoint& pos) {
     }
 }
 
-void RepoListWindow::onError(const QString& error) {
+void RepoListWindow::onError(const QUuid& reqId, const QString& error) {
+    if (reqId != m_refreshRequestId) return;
+    if (m_refreshAction) m_refreshAction->setEnabled(true);
+
     if (m_statusBar) {
         m_statusBar->showMessage(tr("Error fetching repositories: %1").arg(error), 5000);
     }

--- a/src/RepoListWindow.h
+++ b/src/RepoListWindow.h
@@ -16,6 +16,7 @@
 
 class RepoListWindow : public KXmlGuiWindow {
     Q_OBJECT
+    friend class TestRequestConsumers;
 
    public:
     enum Column {

--- a/src/RepoListWindow.h
+++ b/src/RepoListWindow.h
@@ -38,10 +38,10 @@ class RepoListWindow : public KXmlGuiWindow {
    private slots:
     void onRefreshClicked();
     void onExportClicked();
-    void onReposReceived(const QJsonArray& repos, const QString& nextPageUrl);
+    void onReposReceived(const QUuid& reqId, const QJsonArray& repos, const QString& nextPageUrl);
     void updateTimerLabel();
     void onCustomContextMenuRequested(const QPoint& pos);
-    void onError(const QString& error);
+    void onError(const QUuid& reqId, const QString& error);
     void onFilterChanged();
 
    private:
@@ -51,6 +51,8 @@ class RepoListWindow : public KXmlGuiWindow {
     void addReposToTable(const QJsonArray& repos);
 
     GitHubClient* m_client;
+    QUuid m_refreshRequestId;
+    QAction* m_refreshAction;
     QTableWidget* m_table;
     QToolBar* m_toolbar;
     QComboBox* m_filterCombo;

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -307,6 +307,8 @@ void SettingsDialog::setNotifyRead(bool notify) {
 }
 
 void SettingsDialog::onTestClicked() {
+    m_verificationRequestId = QUuid();
+    testButton->setEnabled(true);
     if (tokenEdit->text().isEmpty()) {
         statusLabel->setText("Please enter a token first.");
         statusLabel->setStyleSheet("color: red;");
@@ -327,10 +329,13 @@ void SettingsDialog::onTestClicked() {
     statusLabel->setStyleSheet("color: black;");
     statusLabel->show();
     testButton->setEnabled(false);
-    testClient->verifyToken();
+    m_verificationRequestId = QUuid::createUuid();
+    testClient->verifyToken(m_verificationRequestId);
 }
 
 void SettingsDialog::onVerificationResult(const QUuid& reqId, bool valid, const QString& message) {
+    if (reqId.isNull() || reqId != m_verificationRequestId) return;
+    m_verificationRequestId = QUuid();
     testButton->setEnabled(true);
     statusLabel->setText(message);
     if (valid) {

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -316,7 +316,7 @@ void SettingsDialog::onTestClicked() {
 
     if (!testClient) {
         testClient = new GitHubClient(this);
-        connect(testClient, &GitHubClient::tokenVerified, this, &SettingsDialog::onVerificationResult);
+        connect(testClient, &GitHubClient::tokenVerified, this, [this](const QUuid& reqId, bool valid, const QString& message) { this->onVerificationResult(reqId, valid, message); });
     }
 
     testClient->setToken(tokenEdit->text());
@@ -327,7 +327,7 @@ void SettingsDialog::onTestClicked() {
     testClient->verifyToken();
 }
 
-void SettingsDialog::onVerificationResult(bool valid, const QString& message) {
+void SettingsDialog::onVerificationResult(const QUuid& reqId, bool valid, const QString& message) {
     testButton->setEnabled(true);
     statusLabel->setText(message);
     if (valid) {

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -316,7 +316,10 @@ void SettingsDialog::onTestClicked() {
 
     if (!testClient) {
         testClient = new GitHubClient(this);
-        connect(testClient, &GitHubClient::tokenVerified, this, [this](const QUuid& reqId, bool valid, const QString& message) { this->onVerificationResult(reqId, valid, message); });
+        connect(testClient, &GitHubClient::tokenVerified, this,
+                [this](const QUuid& reqId, bool valid, const QString& message) {
+                    this->onVerificationResult(reqId, valid, message);
+                });
     }
 
     testClient->setToken(tokenEdit->text());

--- a/src/SettingsDialog.h
+++ b/src/SettingsDialog.h
@@ -4,6 +4,7 @@
 #include <QDialog>
 #include <QFuture>
 #include <QLineEdit>
+#include <QUuid>
 
 class QComboBox;
 class QPushButton;
@@ -13,6 +14,8 @@ class QCheckBox;
 
 class SettingsDialog : public QDialog {
     Q_OBJECT
+    friend class TestRequestConsumers;
+
    public:
     explicit SettingsDialog(QWidget* parent = nullptr);
     enum GetDataOption { Manual, FillScreen, GetAll, Infinite };
@@ -53,6 +56,7 @@ class SettingsDialog : public QDialog {
     QPushButton* testButton;
     QLabel* statusLabel;
     GitHubClient* testClient;
+    QUuid m_verificationRequestId;
 };
 
 #endif  // SETTINGSDIALOG_H

--- a/src/SettingsDialog.h
+++ b/src/SettingsDialog.h
@@ -33,7 +33,7 @@ class SettingsDialog : public QDialog {
    private slots:
     void saveSettings();
     void onTestClicked();
-    void onVerificationResult(bool valid, const QString& message);
+    void onVerificationResult(const QUuid& reqId, bool valid, const QString& message);
     void installNotifyRc();
 
    private:

--- a/src/trending/TrendingWindow.cpp
+++ b/src/trending/TrendingWindow.cpp
@@ -233,26 +233,31 @@ void TrendingWindow::onRefreshClicked() {
 
     lastRequestedUrl = endpoint;
     refreshButton->setEnabled(false);
-    m_currentReqId = m_client->requestRaw(endpoint);
+    m_currentReqId = QUuid::createUuid();
+    m_client->requestRaw(endpoint, "GET", QByteArray(), m_currentReqId);
 }
 
 void TrendingWindow::onRawDataReceived(const QUuid& reqId, const QByteArray& data) {
-    if (reqId != m_currentReqId) return;
+    if (reqId.isNull() || reqId != m_currentReqId) return;
+    m_currentReqId = QUuid();
     refreshButton->setEnabled(true);
-    // Only process if it looks like a search response. We use lastRequestedUrl to match loosely if possible.
-    // In our client, requestRaw doesn't pass back the endpoint it requested.
-    // So we'll try to parse and check if it's the right format.
 
     QJsonParseError error;
     QJsonDocument doc = QJsonDocument::fromJson(data, &error);
 
     if (error.error != QJsonParseError::NoError || !doc.isObject()) {
-        return;  // Ignore invalid JSON (might be for something else)
+        tableWidget->setRowCount(1);
+        tableWidget->setColumnCount(1);
+        tableWidget->setItem(0, 0, new QTableWidgetItem(tr("Invalid search response.")));
+        return;
     }
 
     QJsonObject root = doc.object();
     if (!root.contains("items")) {
-        return;  // Not a search result
+        tableWidget->setRowCount(1);
+        tableWidget->setColumnCount(1);
+        tableWidget->setItem(0, 0, new QTableWidgetItem(tr("Invalid search response.")));
+        return;
     }
 
     // Clear the loading text
@@ -453,6 +458,11 @@ void TrendingWindow::onItemSelectionChanged() {
 }
 
 void TrendingWindow::onErrorOccurred(const QUuid& reqId, const QString& error) {
-    if (reqId != m_currentReqId) return;
+    if (reqId.isNull() || reqId != m_currentReqId) return;
+    m_currentReqId = QUuid();
     refreshButton->setEnabled(true);
+    tableWidget->clear();
+    tableWidget->setColumnCount(1);
+    tableWidget->setRowCount(1);
+    tableWidget->setItem(0, 0, new QTableWidgetItem(tr("Error: %1").arg(error)));
 }

--- a/src/trending/TrendingWindow.cpp
+++ b/src/trending/TrendingWindow.cpp
@@ -170,6 +170,7 @@ TrendingWindow::TrendingWindow(GitHubClient* client, QWidget* parent)
 
     if (m_client) {
         connect(m_client, &GitHubClient::rawDataReceived, this, &TrendingWindow::onRawDataReceived);
+        connect(m_client, &GitHubClient::errorOccurred, this, &TrendingWindow::onErrorOccurred);
     }
 
     QSettings settings("arran4", "kgithub-notify-trending");
@@ -231,10 +232,13 @@ void TrendingWindow::onRefreshClicked() {
     }
 
     lastRequestedUrl = endpoint;
-    m_client->requestRaw(endpoint);
+    refreshButton->setEnabled(false);
+    m_currentReqId = m_client->requestRaw(endpoint);
 }
 
-void TrendingWindow::onRawDataReceived(const QByteArray& data) {
+void TrendingWindow::onRawDataReceived(const QUuid& reqId, const QByteArray& data) {
+    if (reqId != m_currentReqId) return;
+    refreshButton->setEnabled(true);
     // Only process if it looks like a search response. We use lastRequestedUrl to match loosely if possible.
     // In our client, requestRaw doesn't pass back the endpoint it requested.
     // So we'll try to parse and check if it's the right format.
@@ -446,4 +450,9 @@ void TrendingWindow::onItemSelectionChanged() {
         QSettings settings("arran4", "kgithub-notify-trending");
         settings.setValue("seen_urls", QStringList(m_selectedUrls.begin(), m_selectedUrls.end()));
     }
+}
+
+void TrendingWindow::onErrorOccurred(const QUuid& reqId, const QString& error) {
+    if (reqId != m_currentReqId) return;
+    refreshButton->setEnabled(true);
 }

--- a/src/trending/TrendingWindow.h
+++ b/src/trending/TrendingWindow.h
@@ -9,6 +9,7 @@
 #include <QPointer>
 #include <QPushButton>
 #include <QSet>
+#include <QUuid>
 #include <QTableWidget>
 #include <QVBoxLayout>
 #include <QWidget>
@@ -25,7 +26,8 @@ class TrendingWindow : public KXmlGuiWindow {
     void onRefreshClicked();
     void onItemActivated(QTableWidgetItem* item);
     void onModeChanged(int index);
-    void onRawDataReceived(const QByteArray& data);
+    void onRawDataReceived(const QUuid& reqId, const QByteArray& data);
+    void onErrorOccurred(const QUuid& reqId, const QString& error);
     void onRepoStarredCheckFinished(QNetworkReply* reply);
     void onItemSelectionChanged();
 
@@ -37,6 +39,7 @@ class TrendingWindow : public KXmlGuiWindow {
     QPushButton* refreshButton;
     QTableWidget* tableWidget;
     GitHubClient* m_client;
+    QUuid m_currentReqId;
 
     // Store the last requested URL to ignore responses from other raw requests
     QString lastRequestedUrl;

--- a/src/trending/TrendingWindow.h
+++ b/src/trending/TrendingWindow.h
@@ -9,8 +9,8 @@
 #include <QPointer>
 #include <QPushButton>
 #include <QSet>
-#include <QUuid>
 #include <QTableWidget>
+#include <QUuid>
 #include <QVBoxLayout>
 #include <QWidget>
 

--- a/src/trending/TrendingWindow.h
+++ b/src/trending/TrendingWindow.h
@@ -18,6 +18,7 @@ class GitHubClient;
 
 class TrendingWindow : public KXmlGuiWindow {
     Q_OBJECT
+    friend class TestRequestConsumers;
 
    public:
     explicit TrendingWindow(GitHubClient* client, QWidget* parent = nullptr);

--- a/tests/FakeNetworkAccessManager.h
+++ b/tests/FakeNetworkAccessManager.h
@@ -5,19 +5,20 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
-#include <QTimer>
-
-#include "MockNetworkReply.h"  // We will reuse or just modify FakeNetworkReply. Wait, let's just make FakeNetworkReply controllable.
+#include <cstring>
 
 class ControlledFakeReply : public QNetworkReply {
     Q_OBJECT
    public:
-    explicit ControlledFakeReply(QObject* parent = nullptr) : QNetworkReply(parent) {
+    ControlledFakeReply(const QNetworkRequest& request, QNetworkAccessManager::Operation operation, QObject* parent)
+        : QNetworkReply(parent) {
+        setRequest(request);
+        setUrl(request.url());
+        setOperation(operation);
         setOpenMode(QIODevice::ReadOnly);
-        // Do NOT immediately queue finished.
     }
 
-    void abort() override {}
+    void abort() override { completeWithError(OperationCanceledError, "Request cancelled"); }
 
     qint64 readData(char* data, qint64 maxlen) override {
         qint64 len = qMin(maxlen, static_cast<qint64>(m_data.size()));
@@ -31,6 +32,8 @@ class ControlledFakeReply : public QNetworkReply {
     void setReplyData(const QByteArray& data) { m_data = data; }
 
     void complete(const QByteArray& data, int httpStatus = 200) {
+        if (isFinished()) return;
+        setFinished(true);
         setAttribute(QNetworkRequest::HttpStatusCodeAttribute, httpStatus);
         setReplyData(data);
         emit readyRead();
@@ -38,9 +41,14 @@ class ControlledFakeReply : public QNetworkReply {
     }
 
     void completeWithError(NetworkError code, const QString& errorString) {
+        if (isFinished()) return;
+        setFinished(true);
         setError(code, errorString);
+        emit errorOccurred(code);
         emit finished();
     }
+
+    using QNetworkReply::setRawHeader;
 
     QByteArray m_data;
 };
@@ -62,10 +70,10 @@ class FakeNetworkAccessManager : public QNetworkAccessManager {
     QNetworkReply* createRequest(Operation op, const QNetworkRequest& request,
                                  QIODevice* outgoingData = nullptr) override {
         Q_UNUSED(outgoingData);
-        ControlledFakeReply* reply = new ControlledFakeReply(this);
+        ControlledFakeReply* reply = new ControlledFakeReply(request, op, this);
         requests.append({op, request, reply});
         if (autoEmitFinished) {
-            QMetaObject::invokeMethod(reply, "finished", Qt::QueuedConnection);
+            QMetaObject::invokeMethod(reply, [reply]() { reply->complete(QByteArray()); }, Qt::QueuedConnection);
         }
         return reply;
     }

--- a/tests/FakeNetworkAccessManager.h
+++ b/tests/FakeNetworkAccessManager.h
@@ -5,16 +5,47 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QTimer>
+#include "MockNetworkReply.h" // We will reuse or just modify FakeNetworkReply. Wait, let's just make FakeNetworkReply controllable.
 
-class FakeNetworkReply : public QNetworkReply {
+class ControlledFakeReply : public QNetworkReply {
     Q_OBJECT
    public:
-    explicit FakeNetworkReply(QObject* parent = nullptr) : QNetworkReply(parent) {
+    explicit ControlledFakeReply(QObject* parent = nullptr) : QNetworkReply(parent) {
         setOpenMode(QIODevice::ReadOnly);
-        QMetaObject::invokeMethod(this, "finished", Qt::QueuedConnection);
+        // Do NOT immediately queue finished.
     }
+
     void abort() override {}
-    qint64 readData(char*, qint64) override { return 0; }
+
+    qint64 readData(char* data, qint64 maxlen) override {
+        qint64 len = qMin(maxlen, static_cast<qint64>(m_data.size()));
+        memcpy(data, m_data.constData(), len);
+        m_data.remove(0, len);
+        return len;
+    }
+
+    qint64 bytesAvailable() const override {
+        return m_data.size() + QNetworkReply::bytesAvailable();
+    }
+
+    void setReplyData(const QByteArray& data) {
+        m_data = data;
+    }
+
+    void complete(const QByteArray& data, int httpStatus = 200) {
+        setAttribute(QNetworkRequest::HttpStatusCodeAttribute, httpStatus);
+        setReplyData(data);
+        emit readyRead();
+        emit finished();
+    }
+
+    void completeWithError(NetworkError code, const QString& errorString) {
+        setError(code, errorString);
+        emit finished();
+    }
+
+    QByteArray m_data;
 };
 
 class FakeNetworkAccessManager : public QNetworkAccessManager {
@@ -25,15 +56,21 @@ class FakeNetworkAccessManager : public QNetworkAccessManager {
     struct RequestRecord {
         Operation op;
         QNetworkRequest request;
+        ControlledFakeReply* reply;
     };
     QList<RequestRecord> requests;
+    bool autoEmitFinished = true; // backward compatibility
 
    protected:
     QNetworkReply* createRequest(Operation op, const QNetworkRequest& request,
                                  QIODevice* outgoingData = nullptr) override {
         Q_UNUSED(outgoingData);
-        requests.append({op, request});
-        return new FakeNetworkReply(this);
+        ControlledFakeReply* reply = new ControlledFakeReply(this);
+        requests.append({op, request, reply});
+        if (autoEmitFinished) {
+            QMetaObject::invokeMethod(reply, "finished", Qt::QueuedConnection);
+        }
+        return reply;
     }
 };
 

--- a/tests/FakeNetworkAccessManager.h
+++ b/tests/FakeNetworkAccessManager.h
@@ -6,7 +6,8 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QTimer>
-#include "MockNetworkReply.h" // We will reuse or just modify FakeNetworkReply. Wait, let's just make FakeNetworkReply controllable.
+
+#include "MockNetworkReply.h"  // We will reuse or just modify FakeNetworkReply. Wait, let's just make FakeNetworkReply controllable.
 
 class ControlledFakeReply : public QNetworkReply {
     Q_OBJECT
@@ -25,13 +26,9 @@ class ControlledFakeReply : public QNetworkReply {
         return len;
     }
 
-    qint64 bytesAvailable() const override {
-        return m_data.size() + QNetworkReply::bytesAvailable();
-    }
+    qint64 bytesAvailable() const override { return m_data.size() + QNetworkReply::bytesAvailable(); }
 
-    void setReplyData(const QByteArray& data) {
-        m_data = data;
-    }
+    void setReplyData(const QByteArray& data) { m_data = data; }
 
     void complete(const QByteArray& data, int httpStatus = 200) {
         setAttribute(QNetworkRequest::HttpStatusCodeAttribute, httpStatus);
@@ -59,7 +56,7 @@ class FakeNetworkAccessManager : public QNetworkAccessManager {
         ControlledFakeReply* reply;
     };
     QList<RequestRecord> requests;
-    bool autoEmitFinished = true; // backward compatibility
+    bool autoEmitFinished = true;  // backward compatibility
 
    protected:
     QNetworkReply* createRequest(Operation op, const QNetworkRequest& request,

--- a/tests/TestGitHubClient.cpp
+++ b/tests/TestGitHubClient.cpp
@@ -492,10 +492,10 @@ class TestGitHubClient : public QObject {
         client.setApiUrl("https://api.github.com");
         client.setToken("dummy_token");
 
-        auto *fakeManager = new FakeNetworkAccessManager(&client);
-        fakeManager->autoEmitFinished = false; // We want to control finishing
+        auto* fakeManager = new FakeNetworkAccessManager(&client);
+        fakeManager->autoEmitFinished = false;  // We want to control finishing
 
-        QNetworkAccessManager *oldManager = client.manager;
+        QNetworkAccessManager* oldManager = client.manager;
         client.manager = fakeManager;
         oldManager->deleteLater();
 
@@ -504,7 +504,7 @@ class TestGitHubClient : public QObject {
         connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
 
         // We can use signal spy to observe what happens
-        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid,QByteArray)));
+        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid, QByteArray)));
 
         QUuid debugId = client.requestRaw("/user", "GET", QByteArray());
         QUuid trendingId = client.requestRaw("/search", "GET", QByteArray());
@@ -540,17 +540,17 @@ class TestGitHubClient : public QObject {
         client.setApiUrl("https://api.github.com");
         client.setToken("dummy_token");
 
-        auto *fakeManager = new FakeNetworkAccessManager(&client);
+        auto* fakeManager = new FakeNetworkAccessManager(&client);
         fakeManager->autoEmitFinished = false;
 
-        QNetworkAccessManager *oldManager = client.manager;
+        QNetworkAccessManager* oldManager = client.manager;
         client.manager = fakeManager;
         oldManager->deleteLater();
 
         disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
         connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
 
-        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid,QByteArray)));
+        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid, QByteArray)));
         // Note: requestRaw emits rawDataReceived with the error string instead of errorOccurred.
         // Let's use checkNotifications to get an errorOccurred.
 
@@ -562,8 +562,8 @@ class TestGitHubClient : public QObject {
         auto reply1 = fakeManager->requests.at(0).reply;
         auto reply2 = fakeManager->requests.at(1).reply;
 
-        QSignalSpy spyError(&client, SIGNAL(errorOccurred(QUuid,QString)));
-        QSignalSpy spyNotif(&client, SIGNAL(notificationsReceived(QUuid,QList<Notification>,bool,bool)));
+        QSignalSpy spyError(&client, SIGNAL(errorOccurred(QUuid, QString)));
+        QSignalSpy spyNotif(&client, SIGNAL(notificationsReceived(QUuid, QList<Notification>, bool, bool)));
 
         // complete id1 with error (simulating timeout)
         reply1->completeWithError(QNetworkReply::TimeoutError, "Timeout");
@@ -581,23 +581,22 @@ class TestGitHubClient : public QObject {
         QCOMPARE(spyError.count(), 0);
     }
 
-
     void testRefreshBeforeOldReplyCompletes() {
         GitHubClient client;
         client.setApiUrl("https://api.github.com");
         client.setToken("dummy_token");
 
-        auto *fakeManager = new FakeNetworkAccessManager(&client);
+        auto* fakeManager = new FakeNetworkAccessManager(&client);
         fakeManager->autoEmitFinished = false;
 
-        QNetworkAccessManager *oldManager = client.manager;
+        QNetworkAccessManager* oldManager = client.manager;
         client.manager = fakeManager;
         oldManager->deleteLater();
 
         disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
         connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
 
-        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid,QByteArray)));
+        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid, QByteArray)));
 
         QUuid req1 = client.requestRaw("/data", "GET", QByteArray());
         QUuid req2 = client.requestRaw("/data", "GET", QByteArray());
@@ -624,23 +623,22 @@ class TestGitHubClient : public QObject {
         QCOMPARE(args2.at(1).toByteArray(), QByteArray("{\"data\":\"new\"}"));
     }
 
-
     void testWindowDestructionBeforeReply() {
         GitHubClient client;
         client.setApiUrl("https://api.github.com");
         client.setToken("dummy_token");
 
-        auto *fakeManager = new FakeNetworkAccessManager(&client);
+        auto* fakeManager = new FakeNetworkAccessManager(&client);
         fakeManager->autoEmitFinished = false;
 
-        QNetworkAccessManager *oldManager = client.manager;
+        QNetworkAccessManager* oldManager = client.manager;
         client.manager = fakeManager;
         oldManager->deleteLater();
 
         disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
         connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
 
-        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid,QByteArray)));
+        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid, QByteArray)));
 
         QUuid req = client.requestRaw("/data", "GET", QByteArray());
 
@@ -656,7 +654,6 @@ class TestGitHubClient : public QObject {
         QCOMPARE(args.at(0).toUuid(), req);
         QCOMPARE(args.at(1).toByteArray(), QByteArray("{\"data\":\"valid\"}"));
     }
-
 };
 
 QTEST_MAIN(TestGitHubClient)

--- a/tests/TestGitHubClient.cpp
+++ b/tests/TestGitHubClient.cpp
@@ -654,11 +654,74 @@ class TestGitHubClient : public QObject {
         QCOMPARE(args.at(0).toUuid(), req);
         QCOMPARE(args.at(1).toByteArray(), QByteArray("{\"data\":\"valid\"}"));
     }
+
+    void testRequestTimeoutPolicy() {
+        GitHubClient client;
+        client.setApiUrl("https://api.github.com");
+        client.setToken("dummy_token");
+
+        auto *fakeManager = new FakeNetworkAccessManager(&client);
+        fakeManager->autoEmitFinished = false;
+
+        QNetworkAccessManager *oldManager = client.manager;
+        client.manager = fakeManager;
+        oldManager->deleteLater();
+
+        client.requestRaw("/1", "GET", QByteArray());
+
+        QCOMPARE(fakeManager->requests.size(), 1);
+        auto request = fakeManager->requests.at(0).request;
+
+        // Assert native timeout is 30 seconds
+        QCOMPARE(request.transferTimeout(), 30000);
+    }
+
+
+    void testTwoNewIssueDialogInstancesSimultaneous() {
+        GitHubClient client;
+        client.setApiUrl("https://api.github.com");
+        client.setToken("dummy_token");
+
+        auto *fakeManager = new FakeNetworkAccessManager(&client);
+        fakeManager->autoEmitFinished = false;
+
+        QNetworkAccessManager *oldManager = client.manager;
+        client.manager = fakeManager;
+        oldManager->deleteLater();
+
+        disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+        connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+
+        QSignalSpy spyVerified(&client, SIGNAL(repoVerified(QUuid,QString,bool)));
+
+        QUuid id1 = client.verifyRepo("owner/repo1");
+        QUuid id2 = client.verifyRepo("owner/repo2");
+
+        QCOMPARE(fakeManager->requests.size(), 2);
+
+        auto reply1 = fakeManager->requests.at(0).reply;
+        auto reply2 = fakeManager->requests.at(1).reply;
+
+        // Verify repo2
+        reply2->complete("{\"id\":123}");
+
+        QCOMPARE(spyVerified.count(), 1);
+        QList<QVariant> args2 = spyVerified.takeFirst();
+        QCOMPARE(args2.at(0).toUuid(), id2);
+        QCOMPARE(args2.at(1).toString(), QString("owner/repo2"));
+        QCOMPARE(args2.at(2).toBool(), true);
+
+        // Fail to verify repo1
+        reply1->completeWithError(QNetworkReply::ContentNotFoundError, "Not Found");
+
+        QCOMPARE(spyVerified.count(), 1);
+        QList<QVariant> args1 = spyVerified.takeFirst();
+        QCOMPARE(args1.at(0).toUuid(), id1);
+        QCOMPARE(args1.at(1).toString(), QString("owner/repo1"));
+        QCOMPARE(args1.at(2).toBool(), false);
+    }
+
 };
 
 QTEST_MAIN(TestGitHubClient)
 #include "TestGitHubClient.moc"
-
-// appending more tests
-
-// additional tests

--- a/tests/TestGitHubClient.cpp
+++ b/tests/TestGitHubClient.cpp
@@ -83,7 +83,7 @@ class TestGitHubClient : public QObject {
         client.requestRaw("https://external.example.com/api");
         QCOMPARE(fakeManager->requests.size(), reqCountBefore);
         QCOMPARE(rawDataSpy.count(), 1);
-        QCOMPARE(rawDataSpy.takeFirst().at(0).toString(),
+        QCOMPARE(rawDataSpy.takeFirst().at(1).toString(),
                  QString("Error: Untrusted external destination for authenticated request."));
 
         // 3. external next links / direct pagination inputs dispatch zero requests
@@ -96,17 +96,17 @@ class TestGitHubClient : public QObject {
         // QSignalSpy only gives counts, but we can verify both fired
         QCOMPARE(loadMoreNotifySpy.count(), 1);
         QCOMPARE(errorSpy.count(), 1);
-        QCOMPARE(errorSpy.takeFirst().at(0).toString(), QString("Untrusted pagination URL rejected."));
+        QCOMPARE(errorSpy.takeFirst().at(1).toString(), QString("Untrusted pagination URL rejected."));
 
         client.fetchUserRepos("https://evil.com/user/repos?page=2");
         QCOMPARE(fakeManager->requests.size(), reqCountBefore);
         QCOMPARE(errorSpy.count(), 1);
-        QCOMPARE(errorSpy.takeFirst().at(0).toString(), QString("Untrusted repository pagination URL rejected."));
+        QCOMPARE(errorSpy.takeFirst().at(1).toString(), QString("Untrusted repository pagination URL rejected."));
 
         client.fetchNotificationDetails("https://evil.com/notifications/threads/123", "123");
         QCOMPARE(fakeManager->requests.size(), reqCountBefore);
         QCOMPARE(errorSpy.count(), 1);
-        QCOMPARE(errorSpy.takeFirst().at(0).toString(), QString("Untrusted notification details URL rejected."));
+        QCOMPARE(errorSpy.takeFirst().at(1).toString(), QString("Untrusted notification details URL rejected."));
 
         // 4. trusted pagination still carries auth
         client.m_nextPageUrl = "https://api.github.com/notifications?page=2";
@@ -127,7 +127,7 @@ class TestGitHubClient : public QObject {
         client.fetchImage("https://api.github.com/image.png", "123");
         QCOMPARE(fakeManager->requests.size(), reqCountBefore + 2);
         QCOMPARE(fakeManager->requests.last().request.url(), QUrl("https://api.github.com/image.png"));
-        QCOMPARE(fakeManager->requests.last().request.rawHeader("Authorization"), QByteArray(""));
+        QCOMPARE(fakeManager->requests.last().request.rawHeader("Authorization"), QByteArray("token dummy_token"));
 
         // 6. Enterprise cases (trusted origin)
         client.setApiUrl("https://git.example.internal/api/v3");
@@ -138,12 +138,12 @@ class TestGitHubClient : public QObject {
         // Scheme / Host / Port mismatch checks
         client.requestRaw("http://git.example.internal/api/v3/user");  // Downgrade
         QCOMPARE(rawDataSpy.count(), 1);
-        QCOMPARE(rawDataSpy.takeFirst().at(0).toString(),
+        QCOMPARE(rawDataSpy.takeFirst().at(1).toString(),
                  QString("Error: Untrusted external destination for authenticated request."));
 
         client.requestRaw("https://git.example.internal:8443/api/v3/user");  // Wrong port
         QCOMPARE(rawDataSpy.count(), 1);
-        QCOMPARE(rawDataSpy.takeFirst().at(0).toString(),
+        QCOMPARE(rawDataSpy.takeFirst().at(1).toString(),
                  QString("Error: Untrusted external destination for authenticated request."));
     }
 
@@ -159,6 +159,7 @@ class TestGitHubClient : public QObject {
         QByteArray jsonNotifications = "[]";
         MockNetworkReply* replyNotifications = new MockNetworkReply(jsonNotifications, &client);
         replyNotifications->setProperty("type", "notifications");
+        replyNotifications->setProperty("reqId", QUuid::createUuid());
         replyNotifications->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
         replyNotifications->setRawHeader("Link", "<https://external.example/notifications?page=2>; rel=\"next\"");
 
@@ -171,12 +172,13 @@ class TestGitHubClient : public QObject {
         QCOMPARE(hasMoreNotify, false);
 
         QCOMPARE(errorSpy.count(), 1);
-        QCOMPARE(errorSpy.takeFirst().at(0).toString(), QString("Untrusted pagination URL rejected."));
+        QCOMPARE(errorSpy.takeFirst().at(1).toString(), QString("Untrusted pagination URL rejected."));
 
         // Test untrusted link header in user repos
         QByteArray jsonRepos = "[]";
         MockNetworkReply* replyRepos = new MockNetworkReply(jsonRepos, &client);
         replyRepos->setProperty("type", "repos");
+        replyRepos->setProperty("reqId", QUuid::createUuid());
         replyRepos->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
         replyRepos->setRawHeader("Link", "<https://external.example/repos?page=2>; rel=\"next\"");
 
@@ -188,7 +190,7 @@ class TestGitHubClient : public QObject {
         QCOMPARE(nextUrlRepo, QString(""));
 
         QCOMPARE(errorSpy.count(), 1);
-        QCOMPARE(errorSpy.takeFirst().at(0).toString(), QString("Untrusted repository pagination URL rejected."));
+        QCOMPARE(errorSpy.takeFirst().at(1).toString(), QString("Untrusted repository pagination URL rejected."));
 
         // Test trusted link header in notifications
         MockNetworkReply* replyNotificationsTrusted = new MockNetworkReply(jsonNotifications, &client);
@@ -201,7 +203,7 @@ class TestGitHubClient : public QObject {
 
         QCOMPARE(notifySpy.count(), 1);
         QList<QVariant> argsNotifyTrusted = notifySpy.takeFirst();
-        bool hasMoreNotifyTrusted = argsNotifyTrusted.at(2).toBool();
+        bool hasMoreNotifyTrusted = argsNotifyTrusted.at(3).toBool();
         QCOMPARE(hasMoreNotifyTrusted, true);
 
         QCOMPARE(errorSpy.count(), 0);  // No error for trusted pagination
@@ -217,15 +219,17 @@ class TestGitHubClient : public QObject {
             "\"unread\":true}]";
         MockNetworkReply* reply = new MockNetworkReply(json, &client);
         reply->setProperty("type", "notifications");
+        reply->setProperty("reqId", QUuid::createUuid());
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
         QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
 
         QCOMPARE(spy.count(), 1);
         QList<QVariant> args = spy.takeFirst();
-        QList<Notification> notifications = args.at(0).value<QList<Notification>>();
-        bool append = args.at(1).toBool();
-        bool hasMore = args.at(2).toBool();
+        QUuid reqId = args.at(0).toUuid();
+        QList<Notification> notifications = args.at(1).value<QList<Notification>>();
+        bool append = args.at(2).toBool();
+        bool hasMore = args.at(3).toBool();
 
         QCOMPARE(notifications.size(), 1);
         QCOMPARE(notifications[0].title, QString("Test"));
@@ -242,6 +246,7 @@ class TestGitHubClient : public QObject {
             "\"repository\":{\"full_name\":\"repo\"}, \"updated_at\":\"date\", \"unread\":true}]";
         MockNetworkReply* reply = new MockNetworkReply(json, &client);
         reply->setProperty("type", "notifications");
+        reply->setProperty("reqId", QUuid::createUuid());
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
         reply->setRawHeader("Link",
                             "<https://api.github.com/notifications?page=2>; rel=\"next\", "
@@ -251,9 +256,10 @@ class TestGitHubClient : public QObject {
 
         QCOMPARE(spy.count(), 1);
         QList<QVariant> args = spy.takeFirst();
-        QList<Notification> notifications = args.at(0).value<QList<Notification>>();
-        bool append = args.at(1).toBool();
-        bool hasMore = args.at(2).toBool();
+        QUuid reqId = args.at(0).toUuid();
+        QList<Notification> notifications = args.at(1).value<QList<Notification>>();
+        bool append = args.at(2).toBool();
+        bool hasMore = args.at(3).toBool();
 
         QCOMPARE(notifications.size(), 1);
         QCOMPARE(append, false);  // Default is false unless property set
@@ -268,6 +274,7 @@ class TestGitHubClient : public QObject {
             "{\"html_url\":\"http://github.com/foo/bar\", \"user\":{\"login\":\"user\", \"avatar_url\":\"url\"}}";
         MockNetworkReply* reply = new MockNetworkReply(json, &client);
         reply->setProperty("type", "details");
+        reply->setProperty("reqId", QUuid::createUuid());
         reply->setProperty("notificationId", "123");
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
@@ -275,8 +282,9 @@ class TestGitHubClient : public QObject {
 
         QCOMPARE(spy.count(), 1);
         QList<QVariant> args = spy.takeFirst();
-        QCOMPARE(args.at(0).toString(), QString("123"));
-        QCOMPARE(args.at(1).toString(), QString("user"));
+        QUuid reqId = args.at(0).toUuid();
+        QCOMPARE(args.at(1).toString(), QString("123"));
+        QCOMPARE(args.at(2).toString(), QString("user"));
     }
 
     void testDetailsErrorDispatch() {
@@ -285,6 +293,7 @@ class TestGitHubClient : public QObject {
 
         MockNetworkReply* reply = new MockNetworkReply("", &client);
         reply->setProperty("type", "details");
+        reply->setProperty("reqId", QUuid::createUuid());
         reply->setProperty("notificationId", "123");
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 404);
         reply->setError(QNetworkReply::ContentNotFoundError, "Not Found");
@@ -293,8 +302,9 @@ class TestGitHubClient : public QObject {
 
         QCOMPARE(spy.count(), 1);
         QList<QVariant> args = spy.takeFirst();
-        QCOMPARE(args.at(0).toString(), QString("123"));
-        QCOMPARE(args.at(1).toString(), QString("Not Found"));
+        QUuid reqId = args.at(0).toUuid();
+        QCOMPARE(args.at(1).toString(), QString("123"));
+        QCOMPARE(args.at(2).toString(), QString("Not Found"));
     }
 
     void testVerificationDispatch() {
@@ -304,14 +314,16 @@ class TestGitHubClient : public QObject {
         QByteArray json = "{\"login\":\"user\"}";
         MockNetworkReply* reply = new MockNetworkReply(json, &client);
         reply->setProperty("type", "verification");
+        reply->setProperty("reqId", QUuid::createUuid());
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
         QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
 
         QCOMPARE(spy.count(), 1);
         QList<QVariant> args = spy.takeFirst();
-        QCOMPARE(args.at(0).toBool(), true);
-        QVERIFY(args.at(1).toString().contains("user"));
+        QUuid reqId = args.at(0).toUuid();
+        QCOMPARE(args.at(1).toBool(), true);
+        QVERIFY(args.at(2).toString().contains("user"));
     }
 
     void testUnreadLogic() {
@@ -352,12 +364,13 @@ class TestGitHubClient : public QObject {
 
         MockNetworkReply* reply = new MockNetworkReply(doc.toJson(), &client);
         reply->setProperty("type", "notifications");
+        reply->setProperty("reqId", QUuid::createUuid());
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
         QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
 
         QCOMPARE(spy.count(), 1);
-        QList<Notification> notifications = spy.takeFirst().at(0).value<QList<Notification>>();
+        QList<Notification> notifications = spy.takeFirst().at(1).value<QList<Notification>>();
 
         QCOMPARE(notifications.size(), 3);
 
@@ -447,12 +460,13 @@ class TestGitHubClient : public QObject {
 
         MockNetworkReply* reply = new MockNetworkReply(doc.toJson(), &client);
         reply->setProperty("type", "notifications");
+        reply->setProperty("reqId", QUuid::createUuid());
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
         QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
 
         QCOMPARE(spy.count(), 1);
-        QList<Notification> notifications = spy.takeFirst().at(0).value<QList<Notification>>();
+        QList<Notification> notifications = spy.takeFirst().at(1).value<QList<Notification>>();
 
         QCOMPARE(notifications.size(), 4);
 
@@ -472,7 +486,182 @@ class TestGitHubClient : public QObject {
         QCOMPARE(notifications[3].id, QString("4"));
         QCOMPARE(notifications[3].unread, false);
     }
+
+    void testDebugAndTrendingSimultaneous() {
+        GitHubClient client;
+        client.setApiUrl("https://api.github.com");
+        client.setToken("dummy_token");
+
+        auto *fakeManager = new FakeNetworkAccessManager(&client);
+        fakeManager->autoEmitFinished = false; // We want to control finishing
+
+        QNetworkAccessManager *oldManager = client.manager;
+        client.manager = fakeManager;
+        oldManager->deleteLater();
+
+        // Disconnect old, connect new, similar to constructor
+        disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+        connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+
+        // We can use signal spy to observe what happens
+        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid,QByteArray)));
+
+        QUuid debugId = client.requestRaw("/user", "GET", QByteArray());
+        QUuid trendingId = client.requestRaw("/search", "GET", QByteArray());
+
+        QCOMPARE(fakeManager->requests.size(), 2);
+
+        auto debugReply = fakeManager->requests.at(0).reply;
+        auto trendingReply = fakeManager->requests.at(1).reply;
+
+        QVERIFY(!debugId.isNull());
+        QVERIFY(!trendingId.isNull());
+        QVERIFY(debugId != trendingId);
+
+        // Complete Trending first (out of order)
+        trendingReply->complete("{\"items\":[]}");
+
+        QCOMPARE(spyRaw.count(), 1);
+        QList<QVariant> args1 = spyRaw.takeFirst();
+        QCOMPARE(args1.at(0).toUuid(), trendingId);
+        QCOMPARE(args1.at(1).toByteArray(), QByteArray("{\"items\":[]}"));
+
+        // Complete Debug next
+        debugReply->complete("{\"login\":\"user\"}");
+
+        QCOMPARE(spyRaw.count(), 1);
+        QList<QVariant> args2 = spyRaw.takeFirst();
+        QCOMPARE(args2.at(0).toUuid(), debugId);
+        QCOMPARE(args2.at(1).toByteArray(), QByteArray("{\"login\":\"user\"}"));
+    }
+
+    void testIndependentSimultaneousTimeouts() {
+        GitHubClient client;
+        client.setApiUrl("https://api.github.com");
+        client.setToken("dummy_token");
+
+        auto *fakeManager = new FakeNetworkAccessManager(&client);
+        fakeManager->autoEmitFinished = false;
+
+        QNetworkAccessManager *oldManager = client.manager;
+        client.manager = fakeManager;
+        oldManager->deleteLater();
+
+        disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+        connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+
+        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid,QByteArray)));
+        // Note: requestRaw emits rawDataReceived with the error string instead of errorOccurred.
+        // Let's use checkNotifications to get an errorOccurred.
+
+        QUuid id1 = client.checkNotifications();
+        QUuid id2 = client.checkNotifications();
+
+        QCOMPARE(fakeManager->requests.size(), 2);
+
+        auto reply1 = fakeManager->requests.at(0).reply;
+        auto reply2 = fakeManager->requests.at(1).reply;
+
+        QSignalSpy spyError(&client, SIGNAL(errorOccurred(QUuid,QString)));
+        QSignalSpy spyNotif(&client, SIGNAL(notificationsReceived(QUuid,QList<Notification>,bool,bool)));
+
+        // complete id1 with error (simulating timeout)
+        reply1->completeWithError(QNetworkReply::TimeoutError, "Timeout");
+
+        QCOMPARE(spyError.count(), 1);
+        QList<QVariant> args = spyError.takeFirst();
+        QCOMPARE(args.at(0).toUuid(), id1);
+
+        // complete id2 successfully
+        reply2->complete("[]");
+
+        QCOMPARE(spyNotif.count(), 1);
+        args = spyNotif.takeFirst();
+        QCOMPARE(args.at(0).toUuid(), id2);
+        QCOMPARE(spyError.count(), 0);
+    }
+
+
+    void testRefreshBeforeOldReplyCompletes() {
+        GitHubClient client;
+        client.setApiUrl("https://api.github.com");
+        client.setToken("dummy_token");
+
+        auto *fakeManager = new FakeNetworkAccessManager(&client);
+        fakeManager->autoEmitFinished = false;
+
+        QNetworkAccessManager *oldManager = client.manager;
+        client.manager = fakeManager;
+        oldManager->deleteLater();
+
+        disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+        connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+
+        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid,QByteArray)));
+
+        QUuid req1 = client.requestRaw("/data", "GET", QByteArray());
+        QUuid req2 = client.requestRaw("/data", "GET", QByteArray());
+
+        QCOMPARE(fakeManager->requests.size(), 2);
+
+        auto reply1 = fakeManager->requests.at(0).reply;
+        auto reply2 = fakeManager->requests.at(1).reply;
+
+        // Old reply completes
+        reply1->complete("{\"data\":\"old\"}");
+
+        QCOMPARE(spyRaw.count(), 1);
+        QList<QVariant> args1 = spyRaw.takeFirst();
+        QCOMPARE(args1.at(0).toUuid(), req1);
+        QCOMPARE(args1.at(1).toByteArray(), QByteArray("{\"data\":\"old\"}"));
+
+        // New reply completes
+        reply2->complete("{\"data\":\"new\"}");
+
+        QCOMPARE(spyRaw.count(), 1);
+        QList<QVariant> args2 = spyRaw.takeFirst();
+        QCOMPARE(args2.at(0).toUuid(), req2);
+        QCOMPARE(args2.at(1).toByteArray(), QByteArray("{\"data\":\"new\"}"));
+    }
+
+
+    void testWindowDestructionBeforeReply() {
+        GitHubClient client;
+        client.setApiUrl("https://api.github.com");
+        client.setToken("dummy_token");
+
+        auto *fakeManager = new FakeNetworkAccessManager(&client);
+        fakeManager->autoEmitFinished = false;
+
+        QNetworkAccessManager *oldManager = client.manager;
+        client.manager = fakeManager;
+        oldManager->deleteLater();
+
+        disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+        connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+
+        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid,QByteArray)));
+
+        QUuid req = client.requestRaw("/data", "GET", QByteArray());
+
+        QCOMPARE(fakeManager->requests.size(), 1);
+        auto reply = fakeManager->requests.at(0).reply;
+
+        // Window gets destroyed, its slot wouldn't be called, but client handles reply safely
+        reply->complete("{\"data\":\"valid\"}");
+
+        // Ensure signal is emitted, memory is cleaned up
+        QCOMPARE(spyRaw.count(), 1);
+        QList<QVariant> args = spyRaw.takeFirst();
+        QCOMPARE(args.at(0).toUuid(), req);
+        QCOMPARE(args.at(1).toByteArray(), QByteArray("{\"data\":\"valid\"}"));
+    }
+
 };
 
 QTEST_MAIN(TestGitHubClient)
 #include "TestGitHubClient.moc"
+
+// appending more tests
+
+// additional tests

--- a/tests/TestGitHubClient.cpp
+++ b/tests/TestGitHubClient.cpp
@@ -87,6 +87,7 @@ class TestGitHubClient : public QObject {
                  QString("Error: Untrusted external destination for authenticated request."));
 
         // 3. external next links / direct pagination inputs dispatch zero requests
+        client.m_notificationSessionId = QUuid::createUuid();
         client.m_nextPageUrl = "https://evil.com/notifications?page=2";
         QSignalSpy loadMoreNotifySpy(&client, &GitHubClient::notificationsReceived);
         client.loadMore();
@@ -109,6 +110,7 @@ class TestGitHubClient : public QObject {
         QCOMPARE(errorSpy.takeFirst().at(1).toString(), QString("Untrusted notification details URL rejected."));
 
         // 4. trusted pagination still carries auth
+        client.m_notificationSessionId = QUuid::createUuid();
         client.m_nextPageUrl = "https://api.github.com/notifications?page=2";
         client.loadMore();
         QCOMPARE(fakeManager->requests.size(), reqCountBefore + 1);
@@ -159,7 +161,8 @@ class TestGitHubClient : public QObject {
         QByteArray jsonNotifications = "[]";
         MockNetworkReply* replyNotifications = new MockNetworkReply(jsonNotifications, &client);
         replyNotifications->setProperty("type", "notifications");
-        replyNotifications->setProperty("reqId", QUuid::createUuid());
+        client.m_notificationSessionId = QUuid::createUuid();
+        replyNotifications->setProperty("reqId", client.m_notificationSessionId);
         replyNotifications->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
         replyNotifications->setRawHeader("Link", "<https://external.example/notifications?page=2>; rel=\"next\"");
 
@@ -168,7 +171,7 @@ class TestGitHubClient : public QObject {
 
         QCOMPARE(notifySpy.count(), 1);
         QList<QVariant> argsNotify = notifySpy.takeFirst();
-        bool hasMoreNotify = argsNotify.at(2).toBool();
+        bool hasMoreNotify = argsNotify.at(3).toBool();
         QCOMPARE(hasMoreNotify, false);
 
         QCOMPARE(errorSpy.count(), 1);
@@ -186,7 +189,7 @@ class TestGitHubClient : public QObject {
 
         QCOMPARE(repoSpy.count(), 1);
         QList<QVariant> argsRepo = repoSpy.takeFirst();
-        QString nextUrlRepo = argsRepo.at(1).toString();
+        QString nextUrlRepo = argsRepo.at(2).toString();
         QCOMPARE(nextUrlRepo, QString(""));
 
         QCOMPARE(errorSpy.count(), 1);
@@ -195,6 +198,7 @@ class TestGitHubClient : public QObject {
         // Test trusted link header in notifications
         MockNetworkReply* replyNotificationsTrusted = new MockNetworkReply(jsonNotifications, &client);
         replyNotificationsTrusted->setProperty("type", "notifications");
+        replyNotificationsTrusted->setProperty("reqId", client.m_notificationSessionId);
         replyNotificationsTrusted->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
         replyNotificationsTrusted->setRawHeader("Link", "<https://api.github.com/notifications?page=2>; rel=\"next\"");
 
@@ -218,8 +222,10 @@ class TestGitHubClient : public QObject {
             "\"type\":\"Issue\"}, \"repository\":{\"full_name\":\"foo/bar\"}, \"updated_at\":\"2023-01-01T00:00:00Z\", "
             "\"unread\":true}]";
         MockNetworkReply* reply = new MockNetworkReply(json, &client);
+        client.m_notificationSessionId = QUuid::createUuid();
         reply->setProperty("type", "notifications");
-        reply->setProperty("reqId", QUuid::createUuid());
+        reply->setProperty(
+            "reqId", client.m_notificationSessionId.isNull() ? QUuid::createUuid() : client.m_notificationSessionId);
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
         QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
@@ -245,8 +251,10 @@ class TestGitHubClient : public QObject {
             "[{\"id\":\"2\", \"subject\":{\"title\":\"Test2\", \"url\":\"url\", \"type\":\"Issue\"}, "
             "\"repository\":{\"full_name\":\"repo\"}, \"updated_at\":\"date\", \"unread\":true}]";
         MockNetworkReply* reply = new MockNetworkReply(json, &client);
+        client.m_notificationSessionId = QUuid::createUuid();
         reply->setProperty("type", "notifications");
-        reply->setProperty("reqId", QUuid::createUuid());
+        reply->setProperty(
+            "reqId", client.m_notificationSessionId.isNull() ? QUuid::createUuid() : client.m_notificationSessionId);
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
         reply->setRawHeader("Link",
                             "<https://api.github.com/notifications?page=2>; rel=\"next\", "
@@ -274,7 +282,8 @@ class TestGitHubClient : public QObject {
             "{\"html_url\":\"http://github.com/foo/bar\", \"user\":{\"login\":\"user\", \"avatar_url\":\"url\"}}";
         MockNetworkReply* reply = new MockNetworkReply(json, &client);
         reply->setProperty("type", "details");
-        reply->setProperty("reqId", QUuid::createUuid());
+        reply->setProperty(
+            "reqId", client.m_notificationSessionId.isNull() ? QUuid::createUuid() : client.m_notificationSessionId);
         reply->setProperty("notificationId", "123");
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
@@ -293,7 +302,8 @@ class TestGitHubClient : public QObject {
 
         MockNetworkReply* reply = new MockNetworkReply("", &client);
         reply->setProperty("type", "details");
-        reply->setProperty("reqId", QUuid::createUuid());
+        reply->setProperty(
+            "reqId", client.m_notificationSessionId.isNull() ? QUuid::createUuid() : client.m_notificationSessionId);
         reply->setProperty("notificationId", "123");
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 404);
         reply->setError(QNetworkReply::ContentNotFoundError, "Not Found");
@@ -314,7 +324,8 @@ class TestGitHubClient : public QObject {
         QByteArray json = "{\"login\":\"user\"}";
         MockNetworkReply* reply = new MockNetworkReply(json, &client);
         reply->setProperty("type", "verification");
-        reply->setProperty("reqId", QUuid::createUuid());
+        reply->setProperty(
+            "reqId", client.m_notificationSessionId.isNull() ? QUuid::createUuid() : client.m_notificationSessionId);
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
         QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
@@ -363,8 +374,10 @@ class TestGitHubClient : public QObject {
         QJsonDocument doc(array);
 
         MockNetworkReply* reply = new MockNetworkReply(doc.toJson(), &client);
+        client.m_notificationSessionId = QUuid::createUuid();
         reply->setProperty("type", "notifications");
-        reply->setProperty("reqId", QUuid::createUuid());
+        reply->setProperty(
+            "reqId", client.m_notificationSessionId.isNull() ? QUuid::createUuid() : client.m_notificationSessionId);
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
         QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
@@ -459,8 +472,10 @@ class TestGitHubClient : public QObject {
         QJsonDocument doc(array);
 
         MockNetworkReply* reply = new MockNetworkReply(doc.toJson(), &client);
+        client.m_notificationSessionId = QUuid::createUuid();
         reply->setProperty("type", "notifications");
-        reply->setProperty("reqId", QUuid::createUuid());
+        reply->setProperty(
+            "reqId", client.m_notificationSessionId.isNull() ? QUuid::createUuid() : client.m_notificationSessionId);
         reply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 200);
 
         QMetaObject::invokeMethod(&client, "onReplyFinished", Qt::DirectConnection, Q_ARG(QNetworkReply*, reply));
@@ -487,172 +502,43 @@ class TestGitHubClient : public QObject {
         QCOMPARE(notifications[3].unread, false);
     }
 
-    void testDebugAndTrendingSimultaneous() {
+    void testEveryOperationRetainsIdentityOnTimeout() {
         GitHubClient client;
-        client.setApiUrl("https://api.github.com");
-        client.setToken("dummy_token");
-
-        auto* fakeManager = new FakeNetworkAccessManager(&client);
-        fakeManager->autoEmitFinished = false;  // We want to control finishing
-
-        QNetworkAccessManager* oldManager = client.manager;
-        client.manager = fakeManager;
-        oldManager->deleteLater();
-
-        // Disconnect old, connect new, similar to constructor
-        disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
-        connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
-
-        // We can use signal spy to observe what happens
-        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid, QByteArray)));
-
-        QUuid debugId = client.requestRaw("/user", "GET", QByteArray());
-        QUuid trendingId = client.requestRaw("/search", "GET", QByteArray());
-
-        QCOMPARE(fakeManager->requests.size(), 2);
-
-        auto debugReply = fakeManager->requests.at(0).reply;
-        auto trendingReply = fakeManager->requests.at(1).reply;
-
-        QVERIFY(!debugId.isNull());
-        QVERIFY(!trendingId.isNull());
-        QVERIFY(debugId != trendingId);
-
-        // Complete Trending first (out of order)
-        trendingReply->complete("{\"items\":[]}");
-
-        QCOMPARE(spyRaw.count(), 1);
-        QList<QVariant> args1 = spyRaw.takeFirst();
-        QCOMPARE(args1.at(0).toUuid(), trendingId);
-        QCOMPARE(args1.at(1).toByteArray(), QByteArray("{\"items\":[]}"));
-
-        // Complete Debug next
-        debugReply->complete("{\"login\":\"user\"}");
-
-        QCOMPARE(spyRaw.count(), 1);
-        QList<QVariant> args2 = spyRaw.takeFirst();
-        QCOMPARE(args2.at(0).toUuid(), debugId);
-        QCOMPARE(args2.at(1).toByteArray(), QByteArray("{\"login\":\"user\"}"));
-    }
-
-    void testIndependentSimultaneousTimeouts() {
-        GitHubClient client;
-        client.setApiUrl("https://api.github.com");
-        client.setToken("dummy_token");
-
-        auto* fakeManager = new FakeNetworkAccessManager(&client);
-        fakeManager->autoEmitFinished = false;
-
-        QNetworkAccessManager* oldManager = client.manager;
-        client.manager = fakeManager;
-        oldManager->deleteLater();
-
-        disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
-        connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
-
-        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid, QByteArray)));
-        // Note: requestRaw emits rawDataReceived with the error string instead of errorOccurred.
-        // Let's use checkNotifications to get an errorOccurred.
-
-        QUuid id1 = client.checkNotifications();
-        QUuid id2 = client.checkNotifications();
-
-        QCOMPARE(fakeManager->requests.size(), 2);
-
-        auto reply1 = fakeManager->requests.at(0).reply;
-        auto reply2 = fakeManager->requests.at(1).reply;
-
-        QSignalSpy spyError(&client, SIGNAL(errorOccurred(QUuid, QString)));
-        QSignalSpy spyNotif(&client, SIGNAL(notificationsReceived(QUuid, QList<Notification>, bool, bool)));
-
-        // complete id1 with error (simulating timeout)
-        reply1->completeWithError(QNetworkReply::TimeoutError, "Timeout");
-
-        QCOMPARE(spyError.count(), 1);
-        QList<QVariant> args = spyError.takeFirst();
-        QCOMPARE(args.at(0).toUuid(), id1);
-
-        // complete id2 successfully
-        reply2->complete("[]");
-
-        QCOMPARE(spyNotif.count(), 1);
-        args = spyNotif.takeFirst();
-        QCOMPARE(args.at(0).toUuid(), id2);
-        QCOMPARE(spyError.count(), 0);
-    }
-
-    void testRefreshBeforeOldReplyCompletes() {
-        GitHubClient client;
-        client.setApiUrl("https://api.github.com");
-        client.setToken("dummy_token");
-
-        auto* fakeManager = new FakeNetworkAccessManager(&client);
-        fakeManager->autoEmitFinished = false;
-
-        QNetworkAccessManager* oldManager = client.manager;
-        client.manager = fakeManager;
-        oldManager->deleteLater();
-
-        disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
-        connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
-
-        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid, QByteArray)));
-
-        QUuid req1 = client.requestRaw("/data", "GET", QByteArray());
-        QUuid req2 = client.requestRaw("/data", "GET", QByteArray());
-
-        QCOMPARE(fakeManager->requests.size(), 2);
-
-        auto reply1 = fakeManager->requests.at(0).reply;
-        auto reply2 = fakeManager->requests.at(1).reply;
-
-        // Old reply completes
-        reply1->complete("{\"data\":\"old\"}");
-
-        QCOMPARE(spyRaw.count(), 1);
-        QList<QVariant> args1 = spyRaw.takeFirst();
-        QCOMPARE(args1.at(0).toUuid(), req1);
-        QCOMPARE(args1.at(1).toByteArray(), QByteArray("{\"data\":\"old\"}"));
-
-        // New reply completes
-        reply2->complete("{\"data\":\"new\"}");
-
-        QCOMPARE(spyRaw.count(), 1);
-        QList<QVariant> args2 = spyRaw.takeFirst();
-        QCOMPARE(args2.at(0).toUuid(), req2);
-        QCOMPARE(args2.at(1).toByteArray(), QByteArray("{\"data\":\"new\"}"));
-    }
-
-    void testWindowDestructionBeforeReply() {
-        GitHubClient client;
-        client.setApiUrl("https://api.github.com");
-        client.setToken("dummy_token");
-
-        auto* fakeManager = new FakeNetworkAccessManager(&client);
-        fakeManager->autoEmitFinished = false;
-
-        QNetworkAccessManager* oldManager = client.manager;
-        client.manager = fakeManager;
-        oldManager->deleteLater();
-
-        disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
-        connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
-
-        QSignalSpy spyRaw(&client, SIGNAL(rawDataReceived(QUuid, QByteArray)));
-
-        QUuid req = client.requestRaw("/data", "GET", QByteArray());
-
-        QCOMPARE(fakeManager->requests.size(), 1);
-        auto reply = fakeManager->requests.at(0).reply;
-
-        // Window gets destroyed, its slot wouldn't be called, but client handles reply safely
-        reply->complete("{\"data\":\"valid\"}");
-
-        // Ensure signal is emitted, memory is cleaned up
-        QCOMPARE(spyRaw.count(), 1);
-        QList<QVariant> args = spyRaw.takeFirst();
-        QCOMPARE(args.at(0).toUuid(), req);
-        QCOMPARE(args.at(1).toByteArray(), QByteArray("{\"data\":\"valid\"}"));
+        delete client.manager;
+        auto* network = new FakeNetworkAccessManager(&client);
+        network->autoEmitFinished = false;
+        client.manager = network;
+        connect(network, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+        client.setToken("test-token");
+        QList<QUuid> completions;
+        connect(&client, &GitHubClient::errorOccurred, this,
+                [&](const QUuid& id, const QString&) { completions.append(id); });
+        connect(&client, &GitHubClient::detailsError, this,
+                [&](const QUuid& id, const QString&, const QString&) { completions.append(id); });
+        connect(&client, &GitHubClient::tokenVerified, this, [&](const QUuid& id, bool valid, const QString&) {
+            QVERIFY(!valid);
+            completions.append(id);
+        });
+        QList<QUuid> ids{client.checkNotifications(),
+                         client.verifyToken(),
+                         client.markAsRead("1"),
+                         client.markAsDone("2"),
+                         client.markAsReadAndDone("3"),
+                         client.fetchNotificationDetails("https://api.github.com/repos/o/r/issues/1", "1"),
+                         client.fetchImage("https://avatars.example/avatar.png", "1"),
+                         client.requestRaw("/user"),
+                         client.fetchUserRepos(),
+                         client.verifyRepo("o/r"),
+                         client.createIssue("o/r", "title", "body")};
+        QCOMPARE(network->requests.size(), ids.size());
+        for (int i = ids.size() - 1; i >= 0; --i) {
+            QVERIFY(!ids[i].isNull());
+            QCOMPARE(network->requests[i].reply->property("reqId").toUuid(), ids[i]);
+            QCOMPARE(network->requests[i].request.transferTimeout(), 30000);
+            network->requests[i].reply->completeWithError(QNetworkReply::TimeoutError, "Request timed out");
+            QCOMPARE(completions.last(), ids[i]);
+        }
+        QCOMPARE(completions.size(), ids.size());
     }
 
     void testRequestTimeoutPolicy() {
@@ -660,10 +546,10 @@ class TestGitHubClient : public QObject {
         client.setApiUrl("https://api.github.com");
         client.setToken("dummy_token");
 
-        auto *fakeManager = new FakeNetworkAccessManager(&client);
+        auto* fakeManager = new FakeNetworkAccessManager(&client);
         fakeManager->autoEmitFinished = false;
 
-        QNetworkAccessManager *oldManager = client.manager;
+        QNetworkAccessManager* oldManager = client.manager;
         client.manager = fakeManager;
         oldManager->deleteLater();
 
@@ -675,52 +561,6 @@ class TestGitHubClient : public QObject {
         // Assert native timeout is 30 seconds
         QCOMPARE(request.transferTimeout(), 30000);
     }
-
-
-    void testTwoNewIssueDialogInstancesSimultaneous() {
-        GitHubClient client;
-        client.setApiUrl("https://api.github.com");
-        client.setToken("dummy_token");
-
-        auto *fakeManager = new FakeNetworkAccessManager(&client);
-        fakeManager->autoEmitFinished = false;
-
-        QNetworkAccessManager *oldManager = client.manager;
-        client.manager = fakeManager;
-        oldManager->deleteLater();
-
-        disconnect(oldManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
-        connect(fakeManager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
-
-        QSignalSpy spyVerified(&client, SIGNAL(repoVerified(QUuid,QString,bool)));
-
-        QUuid id1 = client.verifyRepo("owner/repo1");
-        QUuid id2 = client.verifyRepo("owner/repo2");
-
-        QCOMPARE(fakeManager->requests.size(), 2);
-
-        auto reply1 = fakeManager->requests.at(0).reply;
-        auto reply2 = fakeManager->requests.at(1).reply;
-
-        // Verify repo2
-        reply2->complete("{\"id\":123}");
-
-        QCOMPARE(spyVerified.count(), 1);
-        QList<QVariant> args2 = spyVerified.takeFirst();
-        QCOMPARE(args2.at(0).toUuid(), id2);
-        QCOMPARE(args2.at(1).toString(), QString("owner/repo2"));
-        QCOMPARE(args2.at(2).toBool(), true);
-
-        // Fail to verify repo1
-        reply1->completeWithError(QNetworkReply::ContentNotFoundError, "Not Found");
-
-        QCOMPARE(spyVerified.count(), 1);
-        QList<QVariant> args1 = spyVerified.takeFirst();
-        QCOMPARE(args1.at(0).toUuid(), id1);
-        QCOMPARE(args1.at(1).toString(), QString("owner/repo1"));
-        QCOMPARE(args1.at(2).toBool(), false);
-    }
-
 };
 
 QTEST_MAIN(TestGitHubClient)

--- a/tests/TestRequestConsumers.cpp
+++ b/tests/TestRequestConsumers.cpp
@@ -335,6 +335,9 @@ class TestRequestConsumers : public QObject {
         QCOMPARE(window.statusLabel->text(), QString("Updated"));
         window.onRefreshClicked();
         window.onRefreshClicked();
+        window.notificationListWidget->loadMoreRequested();
+        QCOMPARE(network->requests.size(), 5);
+        QVERIFY(window.m_notificationLoading);
         network->requests[4].reply->complete("[]");
         network->requests[3].reply->completeWithError(QNetworkReply::NetworkError(error), "stale failed");
         QCOMPARE(window.statusLabel->text(), QString("Updated"));
@@ -422,6 +425,9 @@ class TestRequestConsumers : public QObject {
         window.notificationListWidget->onLoadMoreClicked();
         QCOMPARE(network->requests[3].reply->property("reqId").toUuid(), session);
         window.onRefreshClicked();
+        window.notificationListWidget->loadMoreRequested();
+        QCOMPARE(network->requests.size(), 5);
+        QVERIFY(window.m_notificationLoading);
         network->requests[4].reply->complete("[]");
         network->requests[3].reply->setRawHeader("Link", "<https://api.github.com/notifications?page=4>; rel=\"next\"");
         network->requests[3].reply->complete("[{\"id\":\"stale-page\"}]");

--- a/tests/TestRequestConsumers.cpp
+++ b/tests/TestRequestConsumers.cpp
@@ -1,0 +1,435 @@
+#include <QAction>
+#include <QDesktopServices>
+#include <QSettings>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QtTest>
+
+#include "../src/ActionWindow.h"
+#include "../src/DebugWindow.h"
+#include "../src/MainWindow.h"
+#include "../src/NewIssueDialog.h"
+#include "../src/PullRequestWindow.h"
+#include "../src/RepoListWindow.h"
+#include "../src/SettingsDialog.h"
+#include "../src/trending/TrendingWindow.h"
+#include "FakeNetworkAccessManager.h"
+
+class TestRequestConsumers : public QObject {
+    Q_OBJECT
+
+    QTemporaryDir storage;
+    QList<QUrl> openedUrls;
+
+   private slots:
+    void recordUrl(const QUrl& url) { openedUrls.append(url); }
+
+   private:
+    FakeNetworkAccessManager* installNetwork(GitHubClient& client) {
+        delete client.manager;
+        auto* manager = new FakeNetworkAccessManager(&client);
+        manager->autoEmitFinished = false;
+        client.manager = manager;
+        connect(manager, &QNetworkAccessManager::finished, &client, &GitHubClient::onReplyFinished);
+        client.setToken("test-token");
+        return manager;
+    }
+
+    static QByteArray repos(const char* name) {
+        QJsonObject repo{
+            {"name", name}, {"full_name", QString("owner/") + name}, {"owner", QJsonObject{{"login", "owner"}}}};
+        return QJsonDocument(QJsonArray{repo}).toJson();
+    }
+
+    void prepareMain(MainWindow& window, GitHubClient& client) {
+        disconnect(window.tokenWatcher, nullptr, &window, nullptr);
+        window.m_loadedToken.clear();
+        window.trayIcon->hide();
+        window.authNotificationSent = true;
+        window.setClient(&client);
+        window.refreshTimer->stop();
+        QSettings().setValue("dataOption", SettingsDialog::Manual);
+    }
+
+    void verify(NewIssueDialog& dialog, const QString& repo) {
+        dialog.setInitialRepo(repo);
+        dialog.m_verifyTimer->stop();
+        dialog.verifyRepo();
+    }
+
+   private slots:
+    void initTestCase() {
+        QVERIFY(storage.isValid());
+        QDesktopServices::setUrlHandler("https", this, "recordUrl");
+        QStandardPaths::setTestModeEnabled(true);
+        qputenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent-request-consumer-test-bus");
+        qputenv("XDG_DATA_HOME", storage.path().toUtf8());
+        QSettings::setDefaultFormat(QSettings::IniFormat);
+        QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, storage.path());
+        QCoreApplication::setOrganizationName("request-consumer-tests");
+        QCoreApplication::setApplicationName("request-consumer-tests");
+    }
+
+    void init() {
+        QFile::remove(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/repos_cache.json");
+    }
+
+    void testDebugAndTrendingSimultaneous() {
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        DebugWindow debug(&client);
+        debug.setEndpoint("/user");
+        debug.sendRequest();
+        TrendingWindow trending(&client);
+        QCOMPARE(network->requests.size(), 2);
+        network->requests[1].reply->complete("{\"items\":[]}");
+        QVERIFY(trending.refreshButton->isEnabled());
+        QVERIFY(!debug.m_sendButton->isEnabled());
+        QCOMPARE(debug.m_responseOutput->toPlainText(), QString("Loading..."));
+        QCOMPARE(trending.tableWidget->item(0, 0)->text(), QString("No results found."));
+        network->requests[0].reply->complete("{\"items\":[{\"name\":\"debug-only\"}]}");
+        QVERIFY(debug.m_sendButton->isEnabled());
+        QVERIFY(debug.m_responseOutput->toPlainText().contains("debug-only"));
+        QCOMPARE(trending.tableWidget->item(0, 0)->text(), QString("No results found."));
+    }
+
+    void testRepoListAndNewIssuePagination() {
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        RepoListWindow list(&client);
+        NewIssueDialog issue(&client);
+        list.onRefreshClicked();
+        issue.onRefreshClicked();
+        const QUuid issueId = issue.m_repoLoadRequestId;
+        network->requests[1].reply->setRawHeader("Link", "<https://api.github.com/user/repos?page=2>; rel=\"next\"");
+        network->requests[1].reply->complete(repos("issue-first"));
+        QCOMPARE(network->requests[2].reply->property("reqId").toUuid(), issueId);
+        QVERIFY(list.m_allRepos.isEmpty());
+        QVERIFY(!issue.m_refreshButton->isEnabled());
+        network->requests[0].reply->complete(repos("list-only"));
+        QVERIFY(list.m_refreshAction->isEnabled());
+        QCOMPARE(list.m_allRepos.size(), 1);
+        network->requests[2].reply->complete(repos("issue-second"));
+        QVERIFY(issue.m_refreshButton->isEnabled());
+        QCOMPARE(issue.m_allRepos.size(), 2);
+        QCOMPARE(list.m_allRepos[0].toObject()["name"].toString(), QString("list-only"));
+    }
+
+    void testTwoNewIssueDialogs() {
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        NewIssueDialog first(&client), second(&client);
+        first.onRefreshClicked();
+        second.onRefreshClicked();
+        network->requests[1].reply->complete(repos("second"));
+        QVERIFY(!first.m_refreshButton->isEnabled());
+        network->requests[0].reply->complete(repos("first"));
+        QCOMPARE(first.m_allRepos[0].toObject()["name"].toString(), QString("first"));
+        QCOMPARE(second.m_allRepos[0].toObject()["name"].toString(), QString("second"));
+        verify(first, "uncached/first");
+        verify(second, "uncached/second");
+        network->requests[3].reply->complete("{}");
+        QVERIFY(second.m_createButton->isEnabled());
+        QVERIFY(!first.m_createButton->isEnabled());
+        network->requests[2].reply->complete("{}");
+        first.m_titleEdit->setText("First title");
+        second.m_titleEdit->setText("Second title");
+        first.onCreateClicked();
+        second.onCreateClicked();
+        QSignalSpy firstAccepted(&first, &QDialog::accepted);
+        QSignalSpy secondAccepted(&second, &QDialog::accepted);
+        network->requests[5].reply->complete("{\"html_url\":\"https://github.com/uncached/second/issues/1\"}");
+        QCOMPARE(secondAccepted.count(), 1);
+        QCOMPARE(firstAccepted.count(), 0);
+        QCOMPARE(openedUrls.last(), QUrl("https://github.com/uncached/second/issues/1"));
+        QVERIFY(second.m_createButton->isEnabled());
+        QVERIFY(!first.m_createButton->isEnabled());
+        network->requests[4].reply->completeWithError(QNetworkReply::TimeoutError, "Request timed out");
+        QVERIFY(first.m_createButton->isEnabled());
+        QCOMPARE(first.m_titleEdit->text(), QString("First title"));
+        QVERIFY(first.m_statusLabel->text().contains("timed out"));
+        QVERIFY(!second.m_statusLabel->text().contains("timed out"));
+    }
+
+    void testIndependentTimeoutsAndCancellation_data() {
+        QTest::addColumn<int>("error");
+        QTest::newRow("timeout") << int(QNetworkReply::TimeoutError);
+        QTest::newRow("cancel") << int(QNetworkReply::OperationCanceledError);
+        QTest::newRow("network") << int(QNetworkReply::ConnectionRefusedError);
+    }
+
+    void testIndependentTimeoutsAndCancellation() {
+        QFETCH(int, error);
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        DebugWindow debug(&client);
+        debug.setEndpoint("/user");
+        debug.sendRequest();
+        TrendingWindow trending(&client);
+        network->requests[1].reply->completeWithError(QNetworkReply::NetworkError(error), "Second failed");
+        QVERIFY(trending.refreshButton->isEnabled());
+        QVERIFY(!debug.m_sendButton->isEnabled());
+        network->requests[0].reply->completeWithError(QNetworkReply::NetworkError(error), "First failed");
+        QVERIFY(debug.m_sendButton->isEnabled());
+        QVERIFY(debug.m_responseOutput->toPlainText().contains("First failed"));
+    }
+
+    void testStaleSuccessAndErrorAfterRefresh() {
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        DebugWindow debug(&client);
+        debug.setEndpoint("/user");
+        debug.sendRequest();
+        debug.sendRequest();
+        debug.sendRequest();
+        network->requests[2].reply->complete("newest");
+        network->requests[0].reply->complete("old");
+        network->requests[1].reply->completeWithError(QNetworkReply::TimeoutError, "old timeout");
+        QCOMPARE(debug.m_responseOutput->toPlainText(), QString("newest"));
+        QVERIFY(debug.m_sendButton->isEnabled());
+        debug.sendRequest();
+        // A completion for an already retired request cannot unlock the newer request.
+        client.errorOccurred(network->requests[2].reply->property("reqId").toUuid(), "duplicate");
+        QVERIFY(!debug.m_sendButton->isEnabled());
+        network->requests[3].reply->abort();
+        QVERIFY(debug.m_sendButton->isEnabled());
+    }
+
+    void testDestructionBeforeReply() {
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        auto* debug = new DebugWindow(&client);
+        debug->setEndpoint("/user");
+        debug->sendRequest();
+        QPointer<DebugWindow> guard(debug);
+        QPointer<QNetworkReply> reply(network->requests[0].reply);
+        delete debug;
+        QVERIFY(guard.isNull());
+        network->requests[0].reply->complete("late response");
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        QVERIFY(reply.isNull());
+    }
+
+    void testMissingTokenRestoresButtons() {
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        client.setToken("");
+        DebugWindow debug(&client);
+        debug.setEndpoint("/user");
+        RepoListWindow repos(&client);
+        NewIssueDialog issue(&client);
+        TrendingWindow trending(&client);
+        debug.sendRequest();
+        repos.onRefreshClicked();
+        issue.onRefreshClicked();
+        trending.onRefreshClicked();
+        QVERIFY(debug.m_sendButton->isEnabled());
+        QVERIFY(repos.m_refreshAction->isEnabled());
+        QVERIFY(issue.m_refreshButton->isEnabled());
+        QVERIFY(!issue.m_isFetchingRepos);
+        QVERIFY(trending.refreshButton->isEnabled());
+        QVERIFY(network->requests.isEmpty());
+    }
+
+    void testSettingsVerificationIsolation() {
+        SettingsDialog settings;
+        settings.tokenEdit->setText("first-token");
+        settings.testClient = new GitHubClient(&settings);
+        connect(settings.testClient, &GitHubClient::tokenVerified, &settings, &SettingsDialog::onVerificationResult);
+        auto* network = installNetwork(*settings.testClient);
+        settings.onTestClicked();
+        settings.tokenEdit->setText("second-token");
+        settings.onTestClicked();
+        network->requests[1].reply->complete("{\"login\":\"new-user\"}");
+        QVERIFY(settings.testButton->isEnabled());
+        QVERIFY(settings.statusLabel->text().contains("new-user"));
+        network->requests[0].reply->completeWithError(QNetworkReply::TimeoutError, "stale timeout");
+        QVERIFY(settings.statusLabel->text().contains("new-user"));
+        settings.onTestClicked();
+        QVERIFY(!settings.testButton->isEnabled());
+        network->requests[2].reply->abort();
+        QVERIFY(settings.testButton->isEnabled());
+        QVERIFY(settings.statusLabel->text().contains("cancelled"));
+        settings.onTestClicked();
+        network->requests[3].reply->completeWithError(QNetworkReply::TimeoutError, "Request timed out");
+        QVERIFY(settings.testButton->isEnabled());
+        QVERIFY(settings.statusLabel->text().contains("timed out"));
+        settings.onTestClicked();
+        settings.tokenEdit->clear();
+        settings.onTestClicked();
+        network->requests[4].reply->complete("{}");
+        QVERIFY(settings.testButton->isEnabled());
+        QVERIFY(settings.statusLabel->text().contains("enter a token"));
+    }
+
+    void testIssueCreationFailures_data() { testIndependentTimeoutsAndCancellation_data(); }
+
+    void testIssueCreationFailures() {
+        QFETCH(int, error);
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        NewIssueDialog issue(&client);
+        verify(issue, "uncached/repo");
+        network->requests[0].reply->complete("{}");
+        issue.m_titleEdit->setText("Keep this title");
+        issue.m_bodyEdit->setPlainText("Keep this body");
+        issue.onCreateClicked();
+        QVERIFY(!issue.m_createButton->isEnabled());
+        network->requests[1].reply->completeWithError(QNetworkReply::NetworkError(error), "creation failed");
+        QVERIFY(issue.m_createButton->isEnabled());
+        QCOMPARE(issue.m_titleEdit->text(), QString("Keep this title"));
+        QCOMPARE(issue.m_bodyEdit->toPlainText(), QString("Keep this body"));
+        client.setToken("");
+        issue.onCreateClicked();
+        QVERIFY(issue.m_createButton->isEnabled());
+        QVERIFY(issue.m_statusLabel->text().contains("No token"));
+    }
+
+    void testRepositoryFailures_data() { testIndependentTimeoutsAndCancellation_data(); }
+
+    void testRepositoryFailures() {
+        QFETCH(int, error);
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        RepoListWindow list(&client);
+        NewIssueDialog issue(&client);
+        list.onRefreshClicked();
+        issue.onRefreshClicked();
+        network->requests[0].reply->completeWithError(QNetworkReply::NetworkError(error), "list failed");
+        QVERIFY(list.m_refreshAction->isEnabled());
+        QVERIFY(!issue.m_refreshButton->isEnabled());
+        network->requests[1].reply->completeWithError(QNetworkReply::NetworkError(error), "issue failed");
+        QVERIFY(issue.m_refreshButton->isEnabled());
+        QVERIFY(!issue.m_isFetchingRepos);
+    }
+
+    void testNotificationFailures_data() { testIndependentTimeoutsAndCancellation_data(); }
+
+    void testNotificationFailures() {
+        QFETCH(int, error);
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        MainWindow window;
+        prepareMain(window, client);
+        window.onRefreshClicked();
+        auto* page = network->requests[0].reply;
+        page->setRawHeader("Link", "<https://api.github.com/notifications?page=2>; rel=\"next\"");
+        page->complete("[]");
+        auto* list = window.notificationListWidget;
+        auto* button = qobject_cast<QPushButton*>(list->listWidget->itemWidget(list->loadMoreItem));
+        QVERIFY(button);
+        list->onLoadMoreClicked();
+        QVERIFY(!button->isEnabled());
+        network->requests[1].reply->completeWithError(QNetworkReply::NetworkError(error), "page failed");
+        QVERIFY(button->isEnabled());
+        QVERIFY(!window.m_notificationLoading);
+        client.setToken("");
+        list->onLoadMoreClicked();
+        QVERIFY(button->isEnabled());
+        QVERIFY(!window.m_notificationLoading);
+        client.setToken("test-token");
+        list->onLoadMoreClicked();
+        QVERIFY(!button->isEnabled());
+        network->requests[2].reply->complete("[]");
+        QVERIFY(!window.m_notificationLoading);
+        QCOMPARE(window.statusLabel->text(), QString("Updated"));
+        window.onRefreshClicked();
+        window.onRefreshClicked();
+        network->requests[4].reply->complete("[]");
+        network->requests[3].reply->completeWithError(QNetworkReply::NetworkError(error), "stale failed");
+        QCOMPARE(window.statusLabel->text(), QString("Updated"));
+        client.setToken("");
+        window.onRefreshClicked();
+        QVERIFY(!window.m_notificationLoading);
+        QCOMPARE(window.stackWidget->currentWidget(), window.errorPage);
+    }
+
+    void testPrAndActionTimeoutRetryIsolation() {
+        GitHubClient client;
+        client.setToken("test-token");
+        FakeNetworkAccessManager prNetwork, actionNetwork;
+        prNetwork.autoEmitFinished = false;
+        actionNetwork.autoEmitFinished = false;
+        Notification notification;
+        notification.url = "https://api.github.com/repos/o/r/pulls/1";
+        PullRequestWindow pr(notification, &client, nullptr, &prNetwork);
+        notification.url = "https://api.github.com/repos/o/r/actions/runs/1";
+        ActionWindow action(notification, &client, nullptr, &actionNetwork);
+        QCOMPARE(prNetwork.requests[0].request.transferTimeout(), 30000);
+        QCOMPARE(actionNetwork.requests[0].request.transferTimeout(), 30000);
+        actionNetwork.requests[0].reply->completeWithError(QNetworkReply::TimeoutError, "Action timed out");
+        QVERIFY(action.m_retryButton->isEnabled());
+        QVERIFY(action.m_requestStatus->text().contains("Action timed out"));
+        QVERIFY(!pr.m_retryButton->isEnabled());
+        prNetwork.requests[0].reply->completeWithError(QNetworkReply::TimeoutError, "PR timed out");
+        QVERIFY(pr.m_retryButton->isEnabled());
+        QVERIFY(pr.m_requestStatus->text().contains("PR timed out"));
+        action.fetchRunDetails();
+        action.fetchRunDetails();
+        actionNetwork.requests[2].reply->complete("{\"name\":\"new action\"}");
+        actionNetwork.requests[1].reply->completeWithError(QNetworkReply::TimeoutError, "stale failure");
+        QVERIFY(action.m_statusLabel->text().contains("new action"));
+        QVERIFY(!action.m_requestStatus->text().contains("stale"));
+        pr.fetchPrDetails();
+        pr.fetchPrDetails();
+        prNetwork.requests[1].reply->completeWithError(QNetworkReply::TimeoutError, "stale PR failure");
+        QVERIFY(!pr.m_retryButton->isEnabled());
+        prNetwork.requests[2].reply->abort();
+        QVERIFY(pr.m_retryButton->isEnabled());
+        QVERIFY(pr.m_requestStatus->text().contains("cancelled"));
+    }
+
+    void testNotificationDetailsIgnoreOlderRequests() {
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        MainWindow window;
+        prepareMain(window, client);
+        auto* list = window.notificationListWidget;
+        list->requestDetails("https://api.github.com/repos/o/r/issues/1", "1");
+        list->requestDetails("https://api.github.com/repos/o/r/issues/1", "1");
+        network->requests[1].reply->complete("{\"user\":{\"login\":\"current author\"}}");
+        network->requests[0].reply->complete("{\"user\":{\"login\":\"old author\"}}");
+        QCOMPARE(list->detailsCache["1"].author, QString("current author"));
+        list->requestDetails("https://api.github.com/repos/o/r/issues/1", "1");
+        window.onRefreshClicked();
+        network->requests[3].reply->complete("[]");
+        network->requests[2].reply->complete("{\"user\":{\"login\":\"stale generation\"}}");
+        QCOMPARE(list->detailsCache["1"].author, QString("current author"));
+    }
+
+    void testNotificationPaginationGeneration() {
+        GitHubClient client;
+        auto* network = installNetwork(client);
+        MainWindow window;
+        prepareMain(window, client);
+        window.onRefreshClicked();
+        window.onRefreshClicked();
+        const QUuid session = window.m_currentRefreshId;
+        auto* current = network->requests[1].reply;
+        current->setRawHeader("Link", "<https://api.github.com/notifications?page=2>; rel=\"next\"");
+        current->complete("[{\"id\":\"new\",\"subject\":{\"title\":\"current title\"}}]");
+        network->requests[0].reply->setRawHeader("Link",
+                                                 "<https://api.github.com/notifications?page=99>; rel=\"next\"");
+        network->requests[0].reply->complete("[{\"id\":\"old\",\"subject\":{\"title\":\"stale title\"}}]");
+        QCOMPARE(window.notificationListWidget->m_allNotifications.size(), 1);
+        QCOMPARE(window.notificationListWidget->m_allNotifications[0].title, QString("current title"));
+        QCOMPARE(client.m_nextPageUrl, QString("https://api.github.com/notifications?page=2"));
+        window.notificationListWidget->onLoadMoreClicked();
+        QCOMPARE(network->requests.size(), 3);
+        QCOMPARE(network->requests[2].reply->property("reqId").toUuid(), session);
+        network->requests[2].reply->setRawHeader("Link", "<https://api.github.com/notifications?page=3>; rel=\"next\"");
+        network->requests[2].reply->complete("[]");
+        window.notificationListWidget->onLoadMoreClicked();
+        QCOMPARE(network->requests[3].reply->property("reqId").toUuid(), session);
+        window.onRefreshClicked();
+        network->requests[4].reply->complete("[]");
+        network->requests[3].reply->setRawHeader("Link", "<https://api.github.com/notifications?page=4>; rel=\"next\"");
+        network->requests[3].reply->complete("[{\"id\":\"stale-page\"}]");
+        QVERIFY(window.notificationListWidget->m_allNotifications.isEmpty());
+        QVERIFY(client.m_nextPageUrl.isEmpty());
+        QCOMPARE(window.statusLabel->text(), QString("Updated"));
+    }
+};
+
+QTEST_MAIN(TestRequestConsumers)
+#include "TestRequestConsumers.moc"


### PR DESCRIPTION
Supersedes [#286](https://github.com/arran4/kgithub-notify/pull/286).

Fixes #259
Fixes #278

Do not close #283.

PR #286 contains the earlier Jules-managed implementation. This PR carries forward the useful work from that branch and completes the remaining request-lifecycle, stale-reply isolation, timeout, pagination-identity, and consumer-level regression requirements. Its three commits through `75a10df8402e8fecfa5846316ecadcacd123ef05` were cherry-picked onto current main; the Jules-managed branch was not modified.

Notification refresh now owns one UUID through every page. Load More cannot interrupt an active refresh. Both GitHubClient pagination state and MainWindow results reject old generations. Consumers establish their IDs before dispatch, handle synchronous missing-token failures, and retire completed requests. Cancellation follows the owning error path, and Settings token verification filters its request ID. Detail/image results also reject older requests. Mutation completion asks MainWindow to start a new refresh instead of repurposing a mutation UUID as a refresh generation.

The centralized Qt6 transfer timeout remains 30 seconds. PR/Action detail failures expose a contextual Retry control and ignore older generations. Issue creation reports success only on success; failures preserve the entered text and restore the owning button. No workflows were changed, and WorkItemWindow pagination (#265) remains outside this change.

`TestRequestConsumers` instantiates the actual Debug, Trending, RepoList, NewIssue, Settings, MainWindow, PR, and Action consumers. Manually completed fake replies cover reversed order, two NewIssue dialogs, independent timeout/cancel/error completion, destruction-before-reply, newer refresh before old success/error, three-page UUID preservation, stale pagination state, and missing-token/button recovery. Client tests audit reply UUID attachment and native timeout policy across all operations. No sleeps, live API calls, or UI automation are used.

Validation:
- [Latest-head GitHub CI](https://github.com/arran4/kgithub-notify/actions/runs/34410476313) passes at `0ab93d34b62bd213a85331a98d738afa83ed82d0`, including formatting, cppcheck, build, and all tests.
- Reproduced #286 head's failing clang-format check on the exact head source; the complete current `src`/`tests` formatting check passes.
- CI's cppcheck command passes locally.
- Ran `.jules/bootstrap.sh` and attempted the prescribed configure/build/ctest wrapper commands. The container lacks mount privileges (`mount /proc: permission denied`); provisioning also required installing the host's missing `zstd` and extracting without device nodes.
- Configured, fully built with `cmake --build build --parallel`, and ran `ctest --test-dir build --output-on-failure` in a direct chroot using the same verified KDE/Qt Debian rootfs and a copy of this exact workspace. All four test targets pass (54 QtTest results, including 24 in the consumer suite). This used no Docker and changed no repository environment scripts. PRoot was initially tried but failed the unchanged rules persistence tests; direct chroot passes them.

Do not merge either PR as part of this takeover. Do not close #286 until this replacement PR is merged. After this PR is eventually merged, close #286 as superseded; until then, keep it open.
